### PR TITLE
Fix sending emails when admins mark to notify the users

### DIFF
--- a/models/DisputeStatus.js
+++ b/models/DisputeStatus.js
@@ -39,7 +39,7 @@ const DisputeStatus = Class('DisputeStatus').inherits(Krypton.Model)({
       status,
       note,
       disputeId: dispute.id,
-      notify: typeof notify === 'boolean' ? notify : false,
+      notify: typeof notify === 'boolean' || notify === 'on' ? notify : false,
     });
 
     await disputeStatus.save();

--- a/tests/unit/models/DisputeStatus.js
+++ b/tests/unit/models/DisputeStatus.js
@@ -50,7 +50,7 @@ describe('Dispute Status', () => {
         comment: 'Test comment',
         status: DisputeStatuses.update,
         note: 'Just a friendly note',
-        notify: true,
+        notify: 'on',
       });
 
       expect(called).to.be.true;
@@ -61,7 +61,7 @@ describe('Dispute Status', () => {
         comment: 'Test comment',
         status: DisputeStatuses.update,
         note: 'Just a friendly note',
-        notify: false,
+        notify: 'off',
       });
 
       expect(called).to.be.false;


### PR DESCRIPTION
The form-data returned is either `'on'` or `'off'`, but this seems to vary so if it's a boolean value we'll let it be whatever it was set to.