### PR TITLE
 Fix agency address rendering defaulted private student dispute letter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
       - attach_workspace:
           at: ~/tdc-dispute-tools
       - run: sudo apt-get update
-      - run: sudo apt-get install pdftk postgresql-client ghostscript
+      - run: sudo apt-get install pdftk postgresql-client
+      - run: sudo bash ./scripts/install_ghostscript_debian
       - run: yarn test
       - run: yarn report
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/tdc-dispute-tools
   docker:
-    - image: circleci/node:8.9.1
+    - image: circleci/node:8.9.1-stretch
     - image: circleci/postgres:9.6.2-alpine
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
       - attach_workspace:
           at: ~/tdc-dispute-tools
       - run: sudo apt-get update
-      - run: sudo apt-get install pdftk postgresql-client
+      - run: sudo apt-get install pdftk postgresql-client ghostscript
       - run: yarn test
       - run: yarn report
 

--- a/lib/assets/document_templates/private_student_loan_dispute_letter/defaulted.pug
+++ b/lib/assets/document_templates/private_student_loan_dispute_letter/defaulted.pug
@@ -10,6 +10,7 @@
       p #{user.name}
       p #{user.address1}
       p #{user.address2}
+      p &nbsp;
       p #{date}
 
   p Dear #{agency.name},
@@ -37,7 +38,7 @@ style.
     font-family: 'Times';
     font-variant-ligatures: common-ligatures;
   }
-  
+
   .address {
     display: -webkit-flex;
     -webkit-flex-flow: row nowrap;

--- a/scripts/install_ghostscript_debian
+++ b/scripts/install_ghostscript_debian
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+echo "Installing apt testing repositories"
+echo 'APT::Default-Release "stable";' >> /etc/apt/apt.conf.d/99defaultrelease
+echo -e "deb     http://ftp.de.debian.org/debian/    stable main contrib non-free \n\
+deb-src http://ftp.de.debian.org/debian/    stable main contrib non-free \n\
+\n\
+deb     http://security.debian.org/         stable/updates  main contrib non-free" >> /etc/apt/sources.list.d/stable.list
+
+echo -e "deb     http://ftp.de.debian.org/debian/    testing main contrib non-free \n\
+deb-src http://ftp.de.debian.org/debian/    testing main contrib non-free \n\
+\n\
+deb     http://security.debian.org/         testing/updates  main contrib non-free" >> /etc/apt/sources.list.d/testing.list
+
+echo "updating"
+apt-get update
+
+echo "installing"
+apt-get -t testing install ghostscript

--- a/scripts/install_ghostscript_debian
+++ b/scripts/install_ghostscript_debian
@@ -2,15 +2,20 @@
 
 echo "Installing apt testing repositories"
 echo 'APT::Default-Release "stable";' >> /etc/apt/apt.conf.d/99defaultrelease
-echo -e "deb     http://ftp.de.debian.org/debian/    stable main contrib non-free \n\
-deb-src http://ftp.de.debian.org/debian/    stable main contrib non-free \n\
-\n\
-deb     http://security.debian.org/         stable/updates  main contrib non-free" >> /etc/apt/sources.list.d/stable.list
+cat <<EOT >> /etc/apt/sources.list.d/stable.list
+deb     http://ftp.de.debian.org/debian/    stable main contrib non-free
+deb-src http://ftp.de.debian.org/debian/    stable main contrib non-free
 
-echo -e "deb     http://ftp.de.debian.org/debian/    testing main contrib non-free \n\
-deb-src http://ftp.de.debian.org/debian/    testing main contrib non-free \n\
-\n\
-deb     http://security.debian.org/         testing/updates  main contrib non-free" >> /etc/apt/sources.list.d/testing.list
+deb     http://security.debian.org/         stable/updates  main contrib non-free
+EOT
+
+cat<<EOT >> /etc/apt/sources.list.d/testing.list
+deb     http://ftp.de.debian.org/debian/    testing main contrib non-free
+deb-src http://ftp.de.debian.org/debian/    testing main contrib non-free
+
+deb     http://security.debian.org/         testing/updates  main contrib non-free
+EOT
+
 
 echo "updating"
 apt-get update

--- a/services/renderers/tool-configurations/private-student-loan-dispute-letter.js
+++ b/services/renderers/tool-configurations/private-student-loan-dispute-letter.js
@@ -23,7 +23,7 @@ module.exports = {
                 },
                 agency: {
                   name: form['firm-name'],
-                  address: form['firm-address'],
+                  address1: form['firm-address'],
                   address2: getAddress2({ form, prefix: 'firm-' }),
                 },
                 accountNumber: form['account-number'],

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -188,7 +188,10 @@ const helpers = {
     }),
 
   extractPdfText: path =>
-    execSync(`gs -dBATCH -dNOPAUSE -sDEVICE=txtwrite -sOutputFile=- ${path}`).toString('utf-8'),
+    execSync(`gs -dBATCH -dNOPAUSE -sDEVICE=txtwrite -sOutputFile=- ${path}`)
+      .toString('utf-8')
+      .replace(/\t/g, ' ')
+      .replace(/\r\n/g, '\n'),
 };
 
 module.exports = helpers;

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -3,6 +3,7 @@ const uuid = require('uuid');
 const sso = require('../../services/sso');
 const sa = require('superagent');
 const { expect } = require('chai');
+const { execSync } = require('child_process');
 
 const { siteURL, sso: { endpoint } } = CONFIG;
 
@@ -185,6 +186,9 @@ const helpers = {
     req.catch(err => {
       expect(err.status).eq(400);
     }),
+
+  extractPdfText: path =>
+    execSync(`gs -dBATCH -dNOPAUSE -sDEVICE=txtwrite -sOutputFile=- ${path}`).toString('utf-8'),
 };
 
 module.exports = helpers;


### PR DESCRIPTION
Also adds a dependency on ghostscript to the test suite for reading the text contents of the rendered pdf letters back so we can verify their contents to prevent these bugs in the future.