### PR TITLE
redirect to https when not running in development mode

### DIFF
--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -1,5 +1,9 @@
 const middlewares = [
   {
+    name: 'HTTPS',
+    path: 'middlewares/https.js',
+  },
+  {
     name: 'Raven',
     path: 'middlewares/raven-request.js',
   },

--- a/middlewares/https.js
+++ b/middlewares/https.js
@@ -1,0 +1,9 @@
+module.exports = (req, res, next) => {
+  const env = process.env.NODE_ENV || 'development';
+
+  if (env !== 'production' || req.secure) {
+    return next();
+  }
+
+  res.redirect(`https://${req.headers.host}${req.url}`);
+};

--- a/tests/integration/middlewares/httpsTest.js
+++ b/tests/integration/middlewares/httpsTest.js
@@ -1,0 +1,26 @@
+const { testGetPage } = require('../../utils');
+const { expect } = require('chai');
+
+describe('https', () => {
+  before(() => {
+    process.env.NODE_ENV = 'production';
+  });
+
+  after(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('should redirect when running in production mode', () => {
+    const req = testGetPage('/');
+
+    return req
+      .redirects(0)
+      .then(() => {
+        // This shouldn't execute since we are blocking redirects
+        expect.fail();
+      })
+      .catch(err => {
+        expect(err.status).eq(302);
+      });
+  });
+});


### PR DESCRIPTION
This PR adds https redirection as a middleware. We redirect only when running the app in production mode