### PR TITLE
/health-check endpoint

### DIFF
--- a/config/RouteMappings.js
+++ b/config/RouteMappings.js
@@ -57,6 +57,11 @@ const routeMappings = RouteMappings()
     as: 'logout',
   })
 
+  .get('/health-check', {
+    to: 'Home#healthCheck',
+    as: 'healthCheck',
+  })
+
   // Admin
   .namespace('/Admin', mapAdmins =>
     mapAdmins()

--- a/controllers/HomeController.js
+++ b/controllers/HomeController.js
@@ -230,6 +230,10 @@ const HomeController = Class('HomeController').inherits(BaseController)({
       res.cookie(cookieName, '', { expires: new Date() });
       res.redirect(siteURL);
     },
+
+    healthCheck(req, res) {
+      res.send('service is running');
+    },
   },
 });
 

--- a/middlewares/https.js
+++ b/middlewares/https.js
@@ -1,7 +1,9 @@
 module.exports = (req, res, next) => {
   const env = process.env.NODE_ENV || 'development';
 
-  if (env !== 'production' || req.secure) {
+  // /health-check is used by ECS and ALB to check if the container is healthy
+  // it get's confused by the redirecction, so we are skipping that for this route
+  if (env !== 'production' || req.secure || req.url === '/health-check') {
     return next();
   }
 

--- a/tests/integration/middlewares/httpsTest.js
+++ b/tests/integration/middlewares/httpsTest.js
@@ -23,4 +23,17 @@ describe('https', () => {
         expect(err.status).eq(302);
       });
   });
+
+  it('should not redirect when going to the /health-check route', () => {
+    const req = testGetPage('/health-check');
+
+    return req
+      .redirects(0)
+      .then(res => {
+        expect(res.status).eq(200);
+      })
+      .catch(() => {
+        expect.fail();
+      });
+  });
 });


### PR DESCRIPTION
This PR adds a `/health-check` endpoint to be used by ELB (Elastic Load Balancer) to know if the service is running. This endpoint can't have a redirection because health checks don't follow redirects, so we are excluding this endpoint in the HTTPS redirection middleware