### PR TITLE
Update name search to match what discourse filters by

### DIFF
--- a/src/javascripts/components/admin/disputes/AdminShowFormInformationPanel.vue
+++ b/src/javascripts/components/admin/disputes/AdminShowFormInformationPanel.vue
@@ -70,6 +70,7 @@
 <script>
 import get from 'lodash/get';
 import { getUserByExternalId } from '../../../lib/api';
+import { DebtTypes } from '../../../../../shared/enum/DebtTypes';
 
 const getFormOrElse = ({ data, user, statuses: [{ status, pendingSubmission }] }) => {
   if (data && (data.forms || data._forms)) {
@@ -106,7 +107,7 @@ export default {
         Phone: this.form.phone || this.user.phone,
         'Phone 2': this.form.phone2,
         Creditor: this.form['agency-name'] || this.form['firm-name'],
-        'Debt type': this.form['debt-type'] || null,
+        'Debt type': DebtTypes[this.form['debt-type']] || null,
         'Debt amount': this.form['debt-amount'],
       };
     },

--- a/views/admin/disputes/index.pug
+++ b/views/admin/disputes/index.pug
@@ -17,12 +17,12 @@ block content
     table.-fw(cellpadding='0' cellspacing='0')
       thead
         tr
-          th
+          th(style="width: 25%")
             .-input-group-icon
               svg(width='18' height='18'): use(xlink:href='#svg-search')
               input.-k-input.-clean.-fw-700(
                 name="disputesListValue[search]"
-                placeholder='Search...'
+                placeholder='Email, username or IP address'
                 value= queryName
               )
           th
@@ -31,8 +31,9 @@ block content
                 name='disputesListValue[readableId]'
                 placeholder='Search ids...'
                 value= queryFilters && queryFilters.readable_id
+                style="width: 8em"
               )
-          th
+          th(style="width: 15%")
             .-k-select.-clean
               select.-fw-700.-fw(name='disputesListValue[tools]')
                 option(value="") Tools
@@ -41,7 +42,7 @@ block content
                     value= tool.id
                     selected= queryFilters && queryFilters.dispute_tool_id === tool.id
                   )= tool.name
-          th
+          th(style="width: 12%")
             .-k-select.-clean
               select.-fw-700.-fw(name='disputesListValue[status]')
                 option(value="") Status
@@ -87,8 +88,8 @@ block content
           tr
             td
               .flex.items-center
-                img(src=_dispute.user.imageURL alt=(_dispute.user.username || _dispute.user.name) width="50" height="50")
-                p.pl2.-fw-700= (_dispute.user.username || _dispute.user.name)
+                img(src=_dispute.user.imageURL alt=(_dispute.user.name) width="50" height="50")
+                p.pl2.-fw-700= (_dispute.user.name)
             td.-fw-400
               | #{_dispute.readableId}
             td.-fw-500


### PR DESCRIPTION
I already updated the search method before to return the intersection of disputes joined with the user and the users matching the Discourse active user search which searches by username, email and IP address. The readable ids were also taking up a lot more room than they needed on the table so this squishes them in a bit to make room for longer names.

<img width="1792" alt="screen shot 2018-04-18 at 6 54 28 pm" src="https://user-images.githubusercontent.com/24264157/38962157-f0924328-4339-11e8-95fe-0427879696df.png">
