### PR TITLE
Re-render dispute if render is stale; Fix admin disptue form variably required fields 

### DIFF
--- a/controllers/DisputesController.js
+++ b/controllers/DisputesController.js
@@ -285,6 +285,10 @@ const DisputesController = Class('DisputesController').inherits(RestfulControlle
           return true;
         }
 
+        if (dispute.updatedAt > renderer.updatedAt) {
+          return true;
+        }
+
         const currentStatus = _.sortBy(dispute.statuses, 'updatedAt').slice(-1)[0];
 
         return currentStatus.status !== 'Completed' || currentStatus.updatedAt > renderer.updatedAt;

--- a/src/javascripts/_entries/admin/disputes/show.js
+++ b/src/javascripts/_entries/admin/disputes/show.js
@@ -1,6 +1,8 @@
 import NodeSupport from '../../../lib/widget/NodeSupport';
 import Common from '../../../components/Common';
-import { mountDebtAmounts } from '../../../components/disputes/InformationForm';
+import * as informationForm from '../../../components/disputes/InformationForm';
+
+const { mountDebtAmounts, default: DisputesInformationForm } = informationForm;
 
 class ViewAdminDisputesShow extends NodeSupport {
   constructor(config) {
@@ -12,6 +14,14 @@ class ViewAdminDisputesShow extends NodeSupport {
         currentUser: config.currentUser,
         currentURL: config.currentURL,
         isAdmin: true,
+      }),
+    );
+
+    this.appendChild(
+      new DisputesInformationForm({
+        name: 'DisputesInformationForm',
+        dispute: config.dispute,
+        element: document.querySelector('[data-component-form="dispute-personal-information"]'),
       }),
     );
 

--- a/src/stylesheets/_entries/admin/disputes/show.css
+++ b/src/stylesheets/_entries/admin/disputes/show.css
@@ -1,3 +1,5 @@
+@import '../../../components/ConfirmInline';
+
 .-bg-neutral-dark {
   background-color: unset;
 
@@ -9,5 +11,10 @@
 
   hr {
     border: none;
+  }
+
+  .-accent,
+  .-white {
+    color: #000;
   }
 }


### PR DESCRIPTION
Also addresses small bug in the admin dispute form where variably required fields would show up all the time regardless of the status of their dependent field.