### PR TITLE
Add more dispute statuses

### DIFF
--- a/shared/enum/DisputeStatuses.js
+++ b/shared/enum/DisputeStatuses.js
@@ -3,6 +3,9 @@ module.exports = Object.freeze({
   completed: 'Completed',
   inReview: 'In Review',
   documentsSent: 'Documents Sent',
-  update: 'Update',
+  secondDispute: '2nd Dispute',
+  discharged: 'Discharged',
+  contactAdmin: 'Contact Admin',
+  readyToMail: 'Ready to Mail',
   userUpdate: 'User Update',
 });

--- a/shared/enum/DisputeStatuses.js
+++ b/shared/enum/DisputeStatuses.js
@@ -6,6 +6,6 @@ module.exports = Object.freeze({
   secondDispute: '2nd Dispute',
   discharged: 'Discharged',
   contactAdmin: 'Contact Admin',
-  readyToMail: 'Ready to Mail',
+  userToMail: 'User to Mail',
   userUpdate: 'User Update',
 });

--- a/src/stylesheets/components/Modal.css
+++ b/src/stylesheets/components/Modal.css
@@ -33,7 +33,7 @@
   & > svg {
     display: inline-block;
     vertical-align: top;
-    fill: var(--text_1);
+    fill: var(--text-1);
     transform: scale(1);
     transition: transform 100ms ease-out;
   }

--- a/tests/integration/controllers/DisputesControllerTest.js
+++ b/tests/integration/controllers/DisputesControllerTest.js
@@ -17,6 +17,7 @@ const {
   testBadRequest,
   testOk,
 } = require('../../utils');
+const { MemberUpdatedDisputeEmail } = require('../../../services/email');
 const PrivateAttachmentStorage = require('../../../models/PrivateAttachmentStorage');
 
 const urls = CONFIG.router.helpers;
@@ -68,33 +69,51 @@ describe('DisputesController', () => {
   describe('update', () => {
     let url;
     let owner;
+    let send;
+    let dispute;
 
     before(async () => {
       owner = await createUser();
-      const dispute = await createDispute(owner);
+      dispute = await createDispute(owner);
       url = urls.Disputes.update.url(dispute.id);
+
+      send = MemberUpdatedDisputeEmail.prototype.send;
+      MemberUpdatedDisputeEmail.prototype.send = () => Promise.resolve();
+    });
+
+    after(() => {
+      MemberUpdatedDisputeEmail.prototype.send = send;
     });
 
     describe('authorization', () => {
+      const body = { comment: 'hello' };
       describe('when unauthenticated', () => {
-        it('should redirect to login', () => testUnauthenticated(testGetPage(url)));
+        it('should redirect to login', () => testUnauthenticated(testPutPage(url, body)));
       });
 
       describe('when owner', () => {
-        it('should allow', () => testAllowed(testGetPage(url, owner)));
+        it('should allow', () => testAllowed(testPutPage(url, body, owner)));
       });
 
       describe('when user but not owner', () => {
-        it('should reject', () => testForbidden(testGetPage(url, user)));
+        it('should reject', () => testForbidden(testPutPage(url, body, user)));
       });
 
       describe('when admin', () => {
-        it('should allow', () => testAllowed(testGetPage(url, admin)));
+        it('should allow', () => testAllowed(testPutPage(url, body, admin)));
       });
 
       describe('when moderator', () => {
-        it('should reject', () => testForbidden(testGetPage(url, moderator)));
+        it('should reject', () => testForbidden(testPutPage(url, body, moderator)));
       });
+    });
+
+    it('should set the status to User Update', async () => {
+      await testPutPage(url, { comment: 'Something such' }, admin);
+      const { statuses } = await Dispute.findById(dispute.id, '[statuses]');
+      const updatedStatus = statuses.find(s => s.comment === 'Something such');
+      expect(updatedStatus).exist;
+      expect(updatedStatus.status).eq('User Update');
     });
   });
 

--- a/tests/unit/models/DisputeStatus.js
+++ b/tests/unit/models/DisputeStatus.js
@@ -59,7 +59,7 @@ describe('Dispute Status', () => {
           {},
           {
             comment: 'Test comment',
-            status: DisputeStatuses.update,
+            status: DisputeStatuses.inReview,
             note: 'Just a friendly note',
             notify: 'on',
           },
@@ -76,7 +76,7 @@ describe('Dispute Status', () => {
           {},
           {
             comment: 'Test comment',
-            status: DisputeStatuses.update,
+            status: DisputeStatuses.inReview,
             note: 'Just a friendly note',
             notify: 'off',
           },

--- a/views/includes/header.pug
+++ b/views/includes/header.pug
@@ -16,7 +16,7 @@ script.
       { text: 'Medicare For All', href: '#m4a' },
     ];
 
-    if (!{currentUser.admin || (currentUser.groups && currentUser.groups.includes('dispute-admin'))}) {
+    if (!{currentUser && (currentUser.admin || (currentUser.groups && currentUser.groups.includes('dispute-admin')))}) {
       dropdownLinks = [{ text: 'Dispute Administration', href: '/admin/disputes' }].concat(dropdownLinks);
     }
 

--- a/views/includes/header.pug
+++ b/views/includes/header.pug
@@ -7,25 +7,33 @@ script.
    * beginning to render the header. Otherwise we end up with a hole in where the
    * header goes until the bundle is done loading & has begun execution
    */
-  new Vue({
-    el: '#debt-collective-header',
-    render(h) {
-      return h('debt-collective-header', {
-        attrs: {
-          'header-links': [
-            { text: 'Dispute Your Debt', href: '/dispute-tools' },
-            { text: 'Campaigns', href: '#campaigns' },
-            { text: 'Events', href: '#events' },
-          ],
-          'dropdown-links': [
-            { text: 'News', href: '#news' },
-            { text: 'Dispute Your Debt', href: '#dispute-your-debt', onclick: 'window.loggit()' },
-            { text: 'About the Debt Collective', href: '#about' },
-            { text: 'Community Wiki', href: '#wiki' },
-            { text: 'Medicare For All', href: '#m4a' },
-          ],
-          'discourse-endpoint': !{JSON.stringify(discourseEndpoint)},
-        },
-      });
+  (function() {
+    var dropdownLinks = [
+      { text: 'News', href: '#news' },
+      { text: 'Dispute Your Debt', href: '#dispute-your-debt', onclick: 'window.loggit()' },
+      { text: 'About the Debt Collective', href: '#about' },
+      { text: 'Community Wiki', href: '#wiki' },
+      { text: 'Medicare For All', href: '#m4a' },
+    ];
+
+    if (!{currentUser.admin || (currentUser.groups && currentUser.groups.includes('dispute-admin'))}) {
+      dropdownLinks = [{ text: 'Dispute Administration', href: '/admin/disputes' }].concat(dropdownLinks);
     }
-  });
+
+    new Vue({
+      el: '#debt-collective-header',
+      render(h) {
+        return h('debt-collective-header', {
+          attrs: {
+            'header-links': [
+              { text: 'Dispute Your Debt', href: '/dispute-tools' },
+              { text: 'Campaigns', href: '#campaigns' },
+              { text: 'Events', href: '#events' },
+            ],
+            'dropdown-links': dropdownLinks,
+            'discourse-endpoint': !{JSON.stringify(discourseEndpoint)},
+          },
+        });
+      }
+    });
+  })();

--- a/views/layouts/admin.pug
+++ b/views/layouts/admin.pug
@@ -12,6 +12,12 @@ html(lang="en")
       block title
         | The Debt Collective
 
+    script(src=`https://cdn.jsdelivr.net/npm/vue@2.5.16/dist/vue.${NODE_ENV === 'production' ? 'min.' : ''}js`)
+    link(rel='stylesheet' href='https://s3.amazonaws.com/tds-static/css/dc-vue-header/0.0.1/index.min.css')
+    script(src='https://s3.amazonaws.com/tds-static/js/dc-vue-header/0.0.1/index.min.js')
+    script.
+      Vue.component(DebtCollectiveHeader.name, DebtCollectiveHeader)
+
     link(rel="stylesheet" href="/build/admin.css")
 
   body.-is-admin

--- a/views/layouts/shared.pug
+++ b/views/layouts/shared.pug
@@ -10,6 +10,12 @@ html(lang='en')
       block title
         | The Debt Collective
 
+    script(src=`https://cdn.jsdelivr.net/npm/vue@2.5.16/dist/vue.${NODE_ENV === 'production' ? 'min.' : ''}js`)
+    link(rel='stylesheet' href='https://s3.amazonaws.com/tds-static/css/dc-vue-header/0.0.1/index.min.css')
+    script(src='https://s3.amazonaws.com/tds-static/js/dc-vue-header/0.0.1/index.min.js')
+    script.
+      Vue.component(DebtCollectiveHeader.name, DebtCollectiveHeader)
+
     link(rel='stylesheet' href='/build/index.css')
 
   body


### PR DESCRIPTION
Also addresses several bugs and adds the dispute backoffice to the dropdown if the user is an administrator

**Bugs addressed**

1. The code to load up Vue and the header scripts was missing from the admin and shared layouts, making the header not appear for those layouts.
2. The header was not displaying a dispute administration link
3. A CSS variable was misnamed `text_1` instead of `text-1`
