### PR TITLE
making header login/logout work correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ views/includes/svg/sprite.symbol.html
 views/includes/svg/sprite.svg
 .tarima
 config.*.env
+*.sql

--- a/README.md
+++ b/README.md
@@ -94,21 +94,13 @@ command
 
 # Deployment
 
-Infrastructure setup is handled by [debtcollective-terrraform](https://gitlab.com/debtcollective/debtcollective-terraform). Once you have you environment running, you can deploying using:
-
-1. `pm2 deploy ecosystem.json <environment> setup`
-2. `pm2 deploy ecosystem.json <environment>`
-
-For example to deploy to production run
-
-1. `pm2 deploy ecosystem.json production setup`
-2. `pm2 deploy ecosystem.json production`
-
-If you need to change branches, servers etc, feel free to edit `ecosystem.json`
+Infrastructure setup is handled by [debtcollective-terrraform](https://gitlab.com/debtcollective/debtcollective-terraform). Once you have you environment running, you can deploy it using Docker.
 
 ## Configuration Variables
 
-This part is handled by [debtcollective-terrraform](https://gitlab.com/debtcollective/debtcollective-terraform) too, since we are using files for configuration.
+`config.js` is the file that holds all the configuration, you can edit
+this file with values in development, but for production and staging we
+are using environment variables. This part is handled by [debtcollective-terrraform](https://gitlab.com/debtcollective/debtcollective-terraform).
 
 # Design
 
@@ -138,7 +130,7 @@ Please refer to `views/emails/README.md` for specific information for which temp
 
 The doc-comments on the `Email` and `DiscourseMessage` classes are essential reading for understanding how best to build new emails and discourse messages.
 
-# (future) Getting Started
+## Use Docker for development
 
 The easiest way to get started running the dispute-tools locally is through [Docker](https://www.docker.com/).
 
@@ -169,3 +161,46 @@ docker run -idt --env-file ./config/config.local.env --name tdc-dispute-tools -p
 ```
 
 5. Navigate to localhost:8080 in your browser and you should see the home page!
+
+## Discourse
+
+### Enable CORS
+
+Go to the Discourse admin settings and search for _cors_, you need to:
+
+* Set **cors origins** to http://localhost:8080, and any other URL you
+  that needs to login with Discourse
+
+You also need to run Discourse with the env variable `DISCOURSE_ENABLE_CORS=true`
+
+```bash
+env DISCOURSE_ENABLE_CORS=true rails s
+```
+
+### Enable Discourse as SSO provider
+
+Go to the Discourse admin settings and search for _sso_, you need to:
+
+* Set **sso secret** to the same value you have in the config.js
+* Enable **enable sso provider**
+* Enable **sso allows all return paths**
+* Enable **enable sso provider**
+
+### Use production Discourse configuration
+
+We have the configuration that is used by production and staging in
+Terraform, you can take a look at the `discourse` module in the repo and
+take the configuration file from there. With this file you can apply the
+same settings we use in prod locally.
+
+Inside the Discourse directory run
+
+```bash
+rails site_settings:import < settings.yml
+```
+
+To export settings to update the Terraform repo use
+
+```bash
+rails site_settings:export > settings.yml
+```

--- a/config/RouteMappings.js
+++ b/config/RouteMappings.js
@@ -47,7 +47,7 @@ const routeMappings = RouteMappings()
     as: 'tool',
   })
 
-  .post('/login', {
+  .get('/login', {
     to: 'Home#login',
     as: 'login',
   })

--- a/config/config.sample.js
+++ b/config/config.sample.js
@@ -8,8 +8,8 @@ module.exports = {
   appName: process.env.APP_NAME || 'TDC Dispute Tools',
   sso: {
     endpoint: process.env.SSO_ENDPOINT || 'http://localhost:3000/session/sso_provider',
-    secret: process.env.SSO_SECRET || 'this is the sso secret',
-    jwtSecret: process.env.JWT_SECRET || 'this is the jwt secret',
+    secret: process.env.SSO_SECRET || 'change-me-please',
+    jwtSecret: process.env.JWT_SECRET || 'change-me-please',
     cookieName: process.env.SSO_COOKIE_NAME || '_dispute_tools',
     // Chrome doesn't set cookies when their domain is .localhost, so null is a good default
     cookieDomain: process.env.SSO_COOKIE_DOMAIN || null,

--- a/config/middlewares.js
+++ b/config/middlewares.js
@@ -8,10 +8,6 @@ const middlewares = [
     path: 'middlewares/raven-request.js',
   },
   {
-    name: 'Authentication handler',
-    path: 'middlewares/handleAuthentication.js',
-  },
-  {
     name: 'CORS',
     path: 'middlewares/cors.js',
   },
@@ -30,6 +26,10 @@ const middlewares = [
   {
     name: 'Method Override',
     path: 'middlewares/MethodOverride.js',
+  },
+  {
+    name: 'Authentication handler',
+    path: 'middlewares/handleAuthentication.js',
   },
   {
     name: 'Locals',

--- a/controllers/HomeController.js
+++ b/controllers/HomeController.js
@@ -222,7 +222,7 @@ const HomeController = Class('HomeController').inherits(BaseController)({
     },
 
     login(req, res) {
-      res.send({ redirect: sso.buildRedirect(req, req.body.returnTo) });
+      res.redirect(sso.buildRedirect(req, '/'));
     },
 
     logout(req, res) {

--- a/lib/data/form-definitions/validations.js
+++ b/lib/data/form-definitions/validations.js
@@ -1,5 +1,3 @@
-/* globals logger */
-
 const { US_STATES } = require('..');
 
 class FieldValidation {
@@ -118,7 +116,6 @@ FieldValidation.checkbox = new FieldValidation({
 
 class Field {
   constructor({ validations = [], attributes = {}, required, ...rest } = {}) {
-    logger.info(rest.name);
     // Grabs all the other things like name, type, label, etc.
     Object.keys(rest).forEach(k => (this[k] = rest[k]));
 

--- a/views/admin/disputes/index.pug
+++ b/views/admin/disputes/index.pug
@@ -130,14 +130,15 @@ block content
               small(class=`${_dispute.statuses[0].pendingSubmission ? 'Tag': ''} ml2` title=`${_dispute.statuses[0].pendingSubmission ? 'TDC mailed' : ''}`)=`${(_dispute.statuses[0].pendingSubmission ? 'attention':  '')}`
             td.-fw-500.-wsnw= new Date(_dispute.createdAt).toDateString()
             td.center.flex.pt2
-              button.mr2.btn-clear.p1.align-top(data-show)
+              button.mr2.btn-clear.p1.align-top(data-show title="View")
                 svg.-pen.block.align-top(width='15' height='15'): use(xlink:href='#svg-external')
-              button.mr2.btn-clear.p1.align-top(data-add-status)
+              button.mr2.btn-clear.p1.align-top(data-add-status title="Edit")
                 svg.-pen.block.align-top(width='15' height='15'): use(xlink:href='#svg-pencil')
 
               if _dispute.data.signature
                 a.btn-clear.-primary.p1.align-top.inline-block(
-                  href= routeMappings.Disputes.download.url(_dispute.id)
+                  href=routeMappings.Disputes.download.url(_dispute.id)
+                  title="Download"
                 ): svg.-pen.block.align-top(width='14' height='17'): use(xlink:href='#svg-download')
               else
                  button.btn-clear.p1.align-top.-download-disabled(disabled)
@@ -152,6 +153,7 @@ block content
                 input(type="hidden" name="_method" value="DELETE")
                 button.btn-clear.p1(
                   type="submit"
+                  title="Deactivate"
                   data-deactivate-dispute
                 )
                   svg.-pen.block.align-top(width='14' height='18'): use(xlink:href='#svg-ban-circle')

--- a/views/includes/header.pug
+++ b/views/includes/header.pug
@@ -10,14 +10,21 @@ script.
   (function() {
     var dropdownLinks = [
       { text: 'News', href: '#news' },
-      { text: 'Dispute Your Debt', href: '#dispute-your-debt', onclick: 'window.loggit()' },
       { text: 'About the Debt Collective', href: '#about' },
       { text: 'Community Wiki', href: '#wiki' },
       { text: 'Medicare For All', href: '#m4a' },
     ];
 
-    if (!{(currentUser && (currentUser.admin || (currentUser.groups && currentUser.groups.includes('dispute-admin')))) || true}) {
-      dropdownLinks = [{ text: 'Dispute Administration', href: '/admin/disputes' }].concat(dropdownLinks);
+    var headerLinks = [
+      { text: 'Dispute Your Debt', href: '/dispute-tools' },
+      { text: 'Campaigns', href: '#campaigns' },
+      { text: 'Events', href: '#events' },
+    ];
+
+    const currentUser = !{JSON.stringify(currentUser)};
+
+    if (currentUser && (currentUser.admin || (currentUser.groups && currentUser.groups.includes('dispute-admin')))) {
+      headerLinks.push({ text: 'Admin', href: '/admin/disputes' });
     }
 
     new Vue({
@@ -25,14 +32,10 @@ script.
       render(h) {
         return h('debt-collective-header', {
           attrs: {
-            'header-links': [
-              { text: 'Dispute Your Debt', href: '/dispute-tools' },
-              { text: 'Campaigns', href: '#campaigns' },
-              { text: 'Events', href: '#events' },
-            ],
+            'header-links': headerLinks,
             'dropdown-links': dropdownLinks,
             'discourse-endpoint': !{JSON.stringify(discourseEndpoint)},
-            'login-endpoint': '/disputes/my',
+            'login-endpoint': '/login',
             // This should be blank so as to send the logout to just `/logout`
             'tools-endpoint': ''
           },

--- a/views/includes/header.pug
+++ b/views/includes/header.pug
@@ -12,13 +12,13 @@ script.
       { text: 'News', href: '#news' },
       { text: 'About the Debt Collective', href: '#about' },
       { text: 'Community Wiki', href: '#wiki' },
-      { text: 'Medicare For All', href: '#m4a' },
+      { text: 'Medicare For All', href: '#m4a' }
     ];
 
     var headerLinks = [
       { text: 'Dispute Your Debt', href: '/dispute-tools' },
       { text: 'Campaigns', href: '#campaigns' },
-      { text: 'Events', href: '#events' },
+      { text: 'Events', href: '#events' }
     ];
 
     const currentUser = !{JSON.stringify(currentUser)};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,7 +2778,7 @@ dateformat@^3.0.3:
 
 "dc-vue-header@git://github.com/debtcollective/dc-vue-header.git#master":
   version "1.0.0"
-  resolved "git://github.com/debtcollective/dc-vue-header.git#1ddb754d202a81e562da38623fabe84215a1dfed"
+  resolved "git://github.com/debtcollective/dc-vue-header.git#c775fa2b0ccb1ca84b59871f8289f9dd0e44c7d2"
   dependencies:
     postcss-css-variables "^0.8.1"
     postcss-nested "^3.0.0"


### PR DESCRIPTION
This PR makes some changes to the header glue so it works for the dispute tools. Also, adds some information on how to configure Discourse to work with SSO

Changes:

* `/login` now respond to get instead of post
* `redirectTo` param removed from `/login`, login endpoint is fixed in the header component
* Getting currentUser correctly in `header.pug`
* Moving the **Admin** link to be a navigation link.

![image](https://user-images.githubusercontent.com/849872/41196690-31be1cc4-6c15-11e8-9019-8ef7266510b2.png)

This is currently deployed to tools.debtsyndicate.org