### PR TITLE
limiting attachment size to 6mb, improving form styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ views/includes/svg/sprite.svg
 .tarima
 config.*.env
 *.sql
+.vscode

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "postcss-import": "^11.0.0",
     "postcss-nested": "^3.0.0",
     "postcss-reporter": "^5.0.0",
-    "prettier": "1.10.2",
+    "prettier": "1.13.5",
     "prettier-stylelint": "^0.4.2",
     "puppeteer": "^0.13.0",
     "sinon": "^4.1.3",

--- a/src/javascripts/components/disputes/Information.js
+++ b/src/javascripts/components/disputes/Information.js
@@ -1,3 +1,4 @@
+import every from 'lodash/every';
 import { updateDisputeData } from '../../lib/api';
 import Widget from '../../lib/widget';
 import DisputesInformationForm from './InformationForm';
@@ -52,6 +53,31 @@ export default class DisputesInformation extends Widget {
     this._bindEvents();
   }
 
+  _fileInputOnChange(button) {
+    const files = button.files;
+
+    if (!files.length) {
+      return;
+    }
+
+    // validate size
+    const MAX_FILE_SIZE = 6000000;
+    const allFilesUnderMaxSize = every(files, file => file.size < MAX_FILE_SIZE);
+
+    // show error message
+    if (!allFilesUnderMaxSize) {
+      const form = button.form;
+      const footerNotes = form.parentElement.querySelector('[data-footer-notes]');
+      footerNotes.innerText = 'Max file size is 6MB';
+      footerNotes.classList.add('error');
+
+      return;
+    }
+
+    this.UploadSpinnerModal.activate();
+    button.form.submit();
+  }
+
   _bindEvents() {
     this._handleSaveAndCloseModalButtonClick = this._handleSaveAndCloseModalButtonClick.bind(this);
     this.saveAndCloseModalButton.addEventListener(
@@ -68,12 +94,7 @@ export default class DisputesInformation extends Widget {
     }
 
     for (const button of this.uploadButtons) {
-      button.onchange = () => {
-        if (button.files.length) {
-          this.UploadSpinnerModal.activate();
-          button.form.submit();
-        }
-      };
+      button.onchange = this._fileInputOnChange.bind(this, button);
     }
 
     for (const button of this.removeUploadButtons) {

--- a/src/stylesheets/_entries/disputes/show.css
+++ b/src/stylesheets/_entries/disputes/show.css
@@ -56,7 +56,7 @@ fieldset {
   }
 
   &__footer-caption {
-    padding-top: 5px;
+    padding: 5px 0;
     margin-bottom: -26px;
   }
 

--- a/views/includes/disputes/information-form.pug
+++ b/views/includes/disputes/information-form.pug
@@ -23,7 +23,7 @@ include ../../mixins/dispute-tools/form-element
       h4.pt3.center= dispute.user.name
       h4.pb3.center= dispute.user.username
     else
-      h3#modalToolPersonalInfoFormTitle= dispute.disputeTool.name
+      h3.pb2#modalToolPersonalInfoFormTitle= dispute.disputeTool.name
 
     each sets, i in step.fieldSets
       .pt2.pr3.pl3.pb2.mb2.-bg-forms
@@ -48,4 +48,3 @@ include ../../mixins/dispute-tools/form-element
       .col.md-col-6.pt1.pb3.px2: button.-k-btn.btn-primary.-fw.-fw-600(type="submit") Save updated form data
     else
       .pt1.pb3: button.-k-btn.btn-primary.-fw.-fw-600(type="submit") Submit for review
-

--- a/views/includes/disputes/information.pug
+++ b/views/includes/disputes/information.pug
@@ -76,7 +76,7 @@ mixin _uploadCard(step, _completed)
           style='opacity: 0;'
           data-upload-button=''
         )
-    .Tool__Info__footer-caption.center.-caption
+    .Tool__Info__footer-caption.center.-caption(data-footer-notes)
       | #{step.footerNotes}
 
 .Dispute__step-content(

--- a/views/mixins/dispute-tools/form-element.pug
+++ b/views/mixins/dispute-tools/form-element.pug
@@ -45,7 +45,7 @@ mixin _toolsYesNoMixin(field)
 
 
 mixin toolsFormElementMixin(field, index)
-  .col.col-12.p2(class=field.columnClassName)
+  .col.col-12.pb2.pr1(class=field.columnClassName)
     case field.type
       when 'dropdown'
         label.inline-block.pb1.-fw-600= field.label
@@ -134,12 +134,12 @@ mixin toolsFormElementMixin(field, index)
 
       when 'mountable'
       when 'group'
-        fieldset.pb2
+        fieldset.pb1
           if field.title
             h4= field.title
 
           if field.subtitle
-            h5.pb2.-fw-600= field.subtitle
+            h5.-fw-600= field.subtitle
 
           if field.text
             div.pb2!= field.text

--- a/yarn.lock
+++ b/yarn.lock
@@ -8994,9 +8994,9 @@ prettier-stylelint@^0.4.2:
     tempy "^0.2.1"
     update-notifier "^2.2.0"
 
-prettier@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+prettier@1.13.5:
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
 
 prettier@^1.7.0:
   version "1.12.1"


### PR DESCRIPTION
This PR adds file size validation for attachments in Disputes

[![gif](http://recordit.co/ZiF2kY61Sg.gif)](http://recordit.co/ZiF2kY61Sg)

![image](https://user-images.githubusercontent.com/849872/41800930-57c56198-763d-11e8-8964-d4c0b9143feb.png)

Also, improves the style of the forms 

**Before**
![image](https://user-images.githubusercontent.com/849872/41799915-d973830a-7638-11e8-9d65-b5190a43c07a.png)

**After**
![image](https://user-images.githubusercontent.com/849872/41799971-20442212-7639-11e8-9391-235987f63b44.png)

Closes https://github.com/debtcollective/parent/issues/150