### PR TITLE
Masked currency inputs, more lax SSN patterns, reword privacy release questions

### DIFF
--- a/controllers/DisputesController.js
+++ b/controllers/DisputesController.js
@@ -165,7 +165,7 @@ const DisputesController = Class('DisputesController').inherits(RestfulControlle
       }
 
       try {
-        const res = dispute[req.body.command](req.body);
+        const res = dispute[req.body.command](req.body, req);
         if (typeof res.then === 'function') {
           await res;
         }

--- a/lib/data/form-definitions/shared-fields/debtAmount.js
+++ b/lib/data/form-definitions/shared-fields/debtAmount.js
@@ -33,7 +33,8 @@ If you don't see your type of debt, choose "Other" and enter the debt type.`,
 };
 
 exports.field = new Field({
-  name: 'debt-amount',
+  type: 'mountable',
+  name: 'debt-amount-mount-point',
   label: 'Amount of Disputed Debt',
   validations: currency,
 });

--- a/lib/data/form-definitions/shared-fields/debtAmount.js
+++ b/lib/data/form-definitions/shared-fields/debtAmount.js
@@ -37,4 +37,13 @@ exports.field = new Field({
   name: 'debt-amount-mount-point',
   label: 'Amount of Disputed Debt',
   validations: currency,
+  fields: [
+    [
+      new Field({
+        name: 'debt-amount',
+        label: 'Debt amount',
+        validations: currency,
+      }),
+    ],
+  ],
 });

--- a/lib/data/form-definitions/shared-fields/privacyRelease.js
+++ b/lib/data/form-definitions/shared-fields/privacyRelease.js
@@ -13,6 +13,8 @@ module.exports = new Field({
           no: {
             message:
               "Are you sure you don't want to authorize the Debt Collective to advocate directly on your behalf?",
+            okButtonText: 'Yes, I am sure I do not want to authorize this',
+            cancelButtonText: 'No, change my answer to allow the Debt Collective to do so',
           },
         },
       }),

--- a/lib/data/form-definitions/validations.js
+++ b/lib/data/form-definitions/validations.js
@@ -82,9 +82,11 @@ FieldValidation.ssn = new FieldValidation({
      * the HTML input pattern attribute:
      * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-pattern
      */
-    pattern: '[0-9]{3}[-_ ]?[0-9]{2}[-_ ]?[0-9]{4}',
-    'aria-label':
-      'The accepted SSN format is three numbers, a hyphen, two numbers, a hyphen, four numbers',
+    pattern:
+      // This will allow pretty much any string as long as it starts
+      // and ends with a number and contains 9 numbers
+      '[0-9][^0-9]*?[0-9][^0-9]*?[0-9][^0-9]*?[0-9][^0-9]*?[0-9][^0-9]*?[0-9][^0-9]*?[0-9][^0-9]*?[0-9][^0-9]*?[0-9]',
+    'aria-label': 'A valid SSN has 9 digits in it. Any character may be used as a separator',
   },
   validations: ['alphaDash', 'minLength:9', 'maxLength:11', 'ssn'],
 });

--- a/models/Dispute.js
+++ b/models/Dispute.js
@@ -261,7 +261,7 @@ const Dispute = Class('Dispute')
       });
     },
 
-    async setForm({ formName, fieldValues, _isDirty }, req) {
+    async setForm({ formName, fieldValues, _isDirty }) {
       if (!formName) {
         throw new Error('The formName is required');
       }
@@ -289,7 +289,6 @@ const Dispute = Class('Dispute')
         this.data.forms[formName] = fieldValues;
       }
 
-      req.flash('success', 'Your information was successfully updated');
       return this;
     },
 

--- a/models/Dispute.js
+++ b/models/Dispute.js
@@ -261,7 +261,7 @@ const Dispute = Class('Dispute')
       });
     },
 
-    async setForm({ formName, fieldValues, _isDirty }) {
+    async setForm({ formName, fieldValues, _isDirty }, req) {
       if (!formName) {
         throw new Error('The formName is required');
       }
@@ -289,6 +289,7 @@ const Dispute = Class('Dispute')
         this.data.forms[formName] = fieldValues;
       }
 
+      req.flash('success', 'Your information was successfully updated');
       return this;
     },
 

--- a/package.json
+++ b/package.json
@@ -125,11 +125,13 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "superagent": "^3.8.2",
+    "text-mask-addons": "^3.7.2",
     "uuid": "^2.0.2",
     "vue": "^2.5.9",
     "vue-flatpickr-component": "^6.0.0",
     "vue-multiselect": "^2.0.8",
     "vue-template-compiler": "^2.5.9",
+    "vue-text-mask": "^6.1.1",
     "webpack": "^3.10.0",
     "winston": "^2.2.0",
     "winston-loggly-bulk": "^1.3.4"

--- a/src/javascripts/components/ConfirmInline.js
+++ b/src/javascripts/components/ConfirmInline.js
@@ -12,11 +12,13 @@ export default class ConfirmInline extends Widget {
       <div class="ConfirmInline">
         <div class="ConfirmInline__body p2">
           <p class="-fw-500">${data.text}</p>
-          <div class="pt2">
-            <button data-btn-cancel class="-k-btn btn-sm btn-light -fw-600 mr1">
+          <div class="col col-6">
+            <button data-btn-cancel class="btn-sm btn-light -fw-600 mr1">
               ${data.cancelButtonText}
             </button>
-            <button data-btn-ok class="-k-btn btn-sm btn-primary -fw-600">
+          </div>
+          <div class="col col-6">
+            <button data-btn-ok class="btn-sm btn-primary -fw-600">
               ${data.okButtonText}
             </button>
           </div>

--- a/src/javascripts/components/disputes/CurrencyInput.vue
+++ b/src/javascripts/components/disputes/CurrencyInput.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <label :for="`${name}_masked`" class="inline-block pb1 -fw-600">Amount of Disputed Debt</label>
+    <masked-input
+      :name="`${name}_masked`"
+      :mask="numberMask"
+      class="form-control -fw"
+      placeholder="$0.00"
+      type="text"
+      required="required"
+      v-model="amount"
+    />
+    <input :name="name" type="text" aria-hidden="true" class="d-none" :value="cleanedValue" />
+  </div>
+</template>
+
+<script>
+import MaskedInput from 'vue-text-mask';
+import createNumberMask from 'text-mask-addons/src/createNumberMask';
+
+export default {
+  components: { MaskedInput },
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      amount: '',
+    };
+  },
+  computed: {
+    cleanedValue() {
+      return this.amount.replace(/[^0-9.]/g, '');
+    },
+  },
+  methods: {
+    numberMask: createNumberMask({
+      prefix: '$',
+      allowDecimal: true,
+      integerLimit: 6,
+    }),
+  },
+};
+</script>

--- a/src/javascripts/components/disputes/CurrencyInput.vue
+++ b/src/javascripts/components/disputes/CurrencyInput.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <label :for="`${name}_masked`" class="inline-block pb1 -fw-600">Amount of Disputed Debt</label>
+    <label :for="`masked-${name}`" class="inline-block pb1 -fw-600">Amount of Disputed Debt</label>
     <masked-input
-      :name="`${name}_masked`"
+      :name="`masked-${name}`"
       :mask="numberMask"
       class="form-control -fw"
       placeholder="$0.00"
@@ -25,10 +25,15 @@ export default {
       type: String,
       required: true,
     },
+    initialAmount: {
+      type: String,
+      required: false,
+      default: '',
+    },
   },
   data() {
     return {
-      amount: '',
+      amount: this.initialAmount,
     };
   },
   computed: {

--- a/src/javascripts/components/disputes/CurrencyInput.vue
+++ b/src/javascripts/components/disputes/CurrencyInput.vue
@@ -16,7 +16,7 @@
 
 <script>
 import MaskedInput from 'vue-text-mask';
-import createNumberMask from 'text-mask-addons/src/createNumberMask';
+import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 
 export default {
   components: { MaskedInput },

--- a/src/javascripts/components/disputes/DebtAmounts.vue
+++ b/src/javascripts/components/disputes/DebtAmounts.vue
@@ -21,14 +21,14 @@
       />
     </div>
     <div class="col col-4 py2 pl2">
-      <label for="fieldValues[debt-amount]_masked" class="inline-block pb1 -fw-500">Amount</label>
+      <label for="masked-fieldValues[debt-amount]" class="inline-block pb1 -fw-500">Amount</label>
       <masked-input
         class="form-control -fw"
         type="text"
         placeholder="$0.00"
         v-model="amount"
         required="required"
-        name="fieldValues[debt-amount]_masked"
+        name="masked-fieldValues[debt-amount]"
         :mask="numberMask"
       />
       <input

--- a/src/javascripts/components/disputes/DebtAmounts.vue
+++ b/src/javascripts/components/disputes/DebtAmounts.vue
@@ -44,7 +44,7 @@
 
 <script>
 import MaskedInput from 'vue-text-mask';
-import createNumberMask from 'text-mask-addons/src/createNumberMask';
+import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import { DebtTypesCollection } from '../../../../shared/enum/DebtTypes';
 
 const DebtTypeKeys = DebtTypesCollection.map(a => a.key);

--- a/src/javascripts/components/disputes/DebtAmounts.vue
+++ b/src/javascripts/components/disputes/DebtAmounts.vue
@@ -21,15 +21,22 @@
       />
     </div>
     <div class="col col-4 py2 pl2">
-      <label class="inline-block pb1 -fw-500">Amount</label>
+      <label for="fieldValues[debt-amount]_masked" class="inline-block pb1 -fw-500">Amount</label>
       <masked-input
         class="form-control -fw"
         type="text"
         placeholder="$0.00"
         v-model="amount"
         required="required"
-        :name="`fieldValues[debt-amount]`"
+        name="fieldValues[debt-amount]_masked"
         :mask="numberMask"
+      />
+      <input
+        type="text"
+        aria-hidden="true"
+        class="d-none"
+        name="fieldValues[debt-amount]"
+        :value="cleanedValue"
       />
     </div>
   </div>
@@ -60,6 +67,11 @@ export default {
       amount: this.originalDebt.amount,
       cachedOther: '',
     };
+  },
+  computed: {
+    cleanedValue() {
+      return this.amount ? this.amount.replace(/[^0-9.]/g, '') : '';
+    },
   },
   methods: {
     handleTypeSelection({ target: { value } }) {

--- a/src/javascripts/components/disputes/DebtAmounts.vue
+++ b/src/javascripts/components/disputes/DebtAmounts.vue
@@ -10,35 +10,45 @@
     </div>
     <div v-if="typeSelected === 'other'" class="col col-4 p2">
       <label class="inline-block pb1 -fw-500" aria-hidden="true" for="fieldValues[debt-type]" id="other-debt-type-l">Other debt type</label>
-      <input type="text" class="form-control -fw" placeholder="..." name="fieldValues[debt-type]" aria-labelledby="other-debt-type-l" v-model="type" required="required" />
+      <input
+        type="text"
+        class="form-control -fw"
+        placeholder="..."
+        name="fieldValues[debt-type]"
+        aria-labelledby="other-debt-type-l"
+        v-model="type"
+        required="required"
+      />
     </div>
     <div class="col col-4 py2 pl2">
       <label class="inline-block pb1 -fw-500">Amount</label>
-      <input
+      <masked-input
         class="form-control -fw"
-        type="number"
-        min="0"
-        step="0.01"
+        type="text"
         placeholder="$0.00"
         v-model="amount"
         required="required"
         :name="`fieldValues[debt-amount]`"
+        :mask="numberMask"
       />
     </div>
   </div>
 </template>
 
 <script>
+import MaskedInput from 'vue-text-mask';
+import createNumberMask from 'text-mask-addons/src/createNumberMask';
 import { DebtTypesCollection } from '../../../../shared/enum/DebtTypes';
 
 const DebtTypeKeys = DebtTypesCollection.map(a => a.key);
 
 export default {
+  components: { MaskedInput },
   props: {
     originalDebt: {
       type: Object,
       required: false,
-      default: () => ({ type: '', amount: undefined }),
+      default: () => ({ type: '', amount: '' }),
     },
   },
   data() {
@@ -62,6 +72,12 @@ export default {
 
       this.typeSelected = value;
     },
+    numberMask: createNumberMask({
+      prefix: '$',
+      // Limits the length before the decimal, not the amount
+      allowDecimal: true,
+      integerLimit: 6,
+    }),
   },
   created() {
     this.DebtTypes = [...DebtTypesCollection, { key: 'other', value: 'Other' }];

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -6,6 +6,7 @@ import Widget from '../../lib/widget';
 import Button from '../../components/Button';
 import ConfirmInline from '../../components/ConfirmInline';
 import DebtAmounts from './DebtAmounts.vue';
+import CurrencyInput from './CurrencyInput.vue';
 import {
   getCustomSelector,
   getCheckitConfig,
@@ -35,6 +36,17 @@ export const mountDebtAmounts = config => {
   }
 };
 
+export const mountDebtAmount = () => {
+  if (document.getElementById('debt-amount-mount-point')) {
+    return new Vue({
+      el: '#debt-amount-mount-point',
+      render() {
+        return <CurrencyInput name="fieldValues[debt-amount]" />;
+      },
+    }).$children[0];
+  }
+};
+
 export default class DisputesInformationForm extends Widget {
   constructor(config) {
     super(config);
@@ -46,9 +58,8 @@ export default class DisputesInformationForm extends Widget {
       }),
     );
 
-    if (document.getElementById('debt-amounts-mount-point')) {
-      this.debtAmounts = mountDebtAmounts(config);
-    }
+    this.debtAmounts = mountDebtAmounts(config);
+    this.debtAmount = mountDebtAmount();
 
     this.constraints = this._constraintsAll = getCheckitConfig(this.dispute);
 

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -152,8 +152,8 @@ export default class DisputesInformationForm extends Widget {
         className: '-warning mt2',
         data: {
           text: `▲ ${matched.message}`,
-          cancelButtonText: 'No',
-          okButtonText: 'Yes',
+          cancelButtonText: matched.cancelButtonText || 'No',
+          okButtonText: matched.okButtonText || 'Yes',
         },
       }),
     );

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -36,12 +36,20 @@ export const mountDebtAmounts = config => {
   }
 };
 
-export const mountDebtAmount = () => {
+export const mountDebtAmount = config => {
   if (document.getElementById('debt-amount-mount-point')) {
     return new Vue({
       el: '#debt-amount-mount-point',
       render() {
-        return <CurrencyInput name="fieldValues[debt-amount]" />;
+        return (
+          <CurrencyInput
+            name="fieldValues[debt-amount]"
+            initialAmount={get(
+              config.dispute.data._forms || config.dispute.data.forms,
+              'personal-information-form.debt-amount',
+            )}
+          />
+        );
       },
     }).$children[0];
   }
@@ -59,7 +67,7 @@ export default class DisputesInformationForm extends Widget {
     );
 
     this.debtAmounts = mountDebtAmounts(config);
-    this.debtAmount = mountDebtAmount();
+    this.debtAmount = mountDebtAmount(config);
 
     this.constraints = this._constraintsAll = getCheckitConfig(this.dispute);
 

--- a/src/stylesheets/components/ConfirmInline.css
+++ b/src/stylesheets/components/ConfirmInline.css
@@ -2,6 +2,7 @@
   &__body {
     position: relative;
     z-index: 3;
+    overflow: auto;
   }
 
   &.-warning > .ConfirmInline__body {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11203,6 +11203,10 @@ text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
+text-mask-addons@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/text-mask-addons/-/text-mask-addons-3.7.2.tgz#56d34780c94f2ee593a77de6e79b55d56f8a8bb8"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -11852,6 +11856,10 @@ vue-template-compiler@^2.5.9:
 vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
+
+vue-text-mask@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/vue-text-mask/-/vue-text-mask-6.1.1.tgz#57b7e4d133641dbd3354bc23c80fbf794739ec64"
 
 vue@^2.5.9:
   version "2.5.16"


### PR DESCRIPTION
Resolves the issues brought up in https://github.com/debtcollective/parent/issues/169

@annlarson Please confirm that the updated text for the privacy release is good to go or let me know if there are any changes y'all would like to make to it

No demo for the SSN because it's just an update to the regex pattern for it. Basically you'll be able to input anything that starts and ends with a number and contains exactly nine numbers but can have any other junk in between. That means all the following will be valid inputs that we can handle on the backend:

- `123-33-1234`
- `1-2-3-2-2-1-2-3-4`
- `1 2 3 2 2 1 2 3 4`
- `111 33 4444`
- `111.44_______444_______4`

etc...

### Privacy release

![Privacy release demo](http://g.recordit.co/AXsVyISgzr.gif)

### Currency input masks

![Currency input mask demo](http://g.recordit.co/qZhswEQppV.gif)

### Successful form save notice

![Successful form save notice demo](http://g.recordit.co/OUuF80HpZj.gif)