### PR TITLE
Fix Exit form button

### DIFF
--- a/src/javascripts/components/disputes/Information.js
+++ b/src/javascripts/components/disputes/Information.js
@@ -49,6 +49,10 @@ export default class DisputesInformation extends Widget {
     this.uploadButtons = document.querySelectorAll('[data-upload-button]');
     this.removeUploadButtons = document.querySelectorAll('[data-remove-upload-button]');
 
+    this.deactivateDisputeForm = this.element.querySelector(
+      '[data-component-form="deactivate-dispute"]',
+    );
+
     this._bindMoreInfoModal();
     this._bindEvents();
   }
@@ -88,6 +92,9 @@ export default class DisputesInformation extends Widget {
     this._handleButtonClickRef = this._handleButtonClick.bind(this);
     this.personalInfoButton.addEventListener('click', this._handleButtonClickRef);
 
+    this._handleDeactivateDisputeRef = this._handleDeactivateDispute.bind(this);
+    this.DisputesInformationForm.bind('deactivateDispute', this._handleDeactivateDisputeRef);
+
     if (this.informationSubmitButton) {
       this._displayNextStepRef = this._displayNextStep.bind(this);
       this.informationSubmitButton.addEventListener('click', this._displayNextStepRef);
@@ -115,6 +122,16 @@ export default class DisputesInformation extends Widget {
     }).then(({ dispute }) => (this.dispute = dispute));
 
     this.ModalInformationForm.deactivate();
+  }
+
+  /**
+   * Submits the `deactivate-dispute` form.
+   * @private
+   * @listens @module:DisputesInformationForm~event:deactivateDispute
+   * @return undefined
+   */
+  _handleDeactivateDispute() {
+    this.deactivateDisputeForm.submit();
   }
 
   _bindMoreInfoModal() {

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -195,7 +195,7 @@ export default class DisputesInformationForm extends Widget {
         data: {
           text: `▲ ${matched.message}`,
           cancelButtonText: `Select ${oppositeAction}`,
-          okButtonText: 'Exit form',
+          okButtonText: 'Exit and deactivate dispute',
         },
       }),
     );

--- a/views/admin/disputes/index.pug
+++ b/views/admin/disputes/index.pug
@@ -93,7 +93,7 @@ block content
         each _dispute in disputes
 
           -
-            // add the user account image to be accesible on the front-end
+            // add the user account image to be accessible on the front-end
             _dispute.user.imageURL = '/images/profile/placeholder-small.png';
 
             //- TODO Use Discourse provided profile image


### PR DESCRIPTION
https://github.com/debtcollective/parent/issues/147

Looking at the code, the button was actually supposed to deactivate the dispute in addition to closing the form. I made it do that again. I changed the button text to make that clearer.


![deactivate](https://user-images.githubusercontent.com/1402948/43411130-4e3b420a-93f7-11e8-947b-a120fc8c9d6e.gif)

