### PR TITLE
don't show deactivated disputes

### DIFF
--- a/middlewares/locals.js
+++ b/middlewares/locals.js
@@ -1,5 +1,7 @@
 const config = require('../config/config');
 const Router = require('../config/RouteMappings');
+const _ = require('lodash');
+const moment = require('moment');
 
 const {
   sso: { logout },
@@ -38,6 +40,9 @@ module.exports = function locals(req, res, next) {
     secondary:
       'https://s3.amazonaws.com/tds-static/img/debtcollective/0.0.1/DC-logo_FULL_DARK_CUTOUTfoot_@3x.png',
   };
+
+  res.locals.lodash = _;
+  res.locals.moment = moment;
 
   return next();
 };

--- a/middlewares/locals.js
+++ b/middlewares/locals.js
@@ -44,5 +44,7 @@ module.exports = function locals(req, res, next) {
   res.locals.lodash = _;
   res.locals.moment = moment;
 
+  res.locals.slugify = (str = '') => str.toLowerCase().replace(/\W/g, '-');
+
   return next();
 };

--- a/models/Dispute.js
+++ b/models/Dispute.js
@@ -32,7 +32,7 @@ const Dispute = Class('Dispute')
   defaultIncludes: '[user, statuses]',
 
   async search(qs) {
-    const query = this.query().where({ deactivated: false });
+    const query = this.query();
 
     if (qs.filters) {
       // If we're passed a human readable id just search by that and ignore everything else
@@ -444,5 +444,12 @@ const Dispute = Class('Dispute')
     },
   },
 });
+
+// filter out deactivated disputes by default
+Dispute.oldQuery = Dispute.query;
+Dispute.query = function (knex, includeDeactivated = false) {
+  const query = Dispute.oldQuery(knex);
+  return includeDeactivated ? query : query.andWhere({ deactivated: false });
+};
 
 module.exports = Dispute;

--- a/models/Dispute.js
+++ b/models/Dispute.js
@@ -32,6 +32,7 @@ const Dispute = Class('Dispute')
   defaultIncludes: '[user, statuses]',
 
   async search(qs) {
+    // back-end search
     const query = this.query();
 
     if (qs.filters) {
@@ -87,7 +88,8 @@ const Dispute = Class('Dispute')
   },
 
   async findById(id, include = null) {
-    const query = Dispute.query().where({ id });
+    const INCLUDE_DEACTIVATED = true;
+    const query = Dispute.query(null, INCLUDE_DEACTIVATED).where({ id });
     if (typeof include === 'string') {
       query.include(include);
     }

--- a/src/javascripts/components/disputes/DebtAmounts.vue
+++ b/src/javascripts/components/disputes/DebtAmounts.vue
@@ -6,6 +6,7 @@
         <select class="-fw form-control" @input="handleTypeSelection" :value="typeSelected" :name="typeSelected !== 'other' ? 'fieldValues[debt-type]' : 'debt-type[other]'" aria-labelledby="debt-type-l" required="required">
           <option v-for="debtType in DebtTypes" :key="debtType.key" :value="debtType.key">{{debtType.value}}</option>
         </select>
+        <p class="-on-error -danger -caption -fw-500 mt1"></p>
       </div>
     </div>
     <div v-if="typeSelected === 'other'" class="col col-4 p2">
@@ -19,6 +20,7 @@
         v-model="type"
         required="required"
       />
+      <p class="-on-error -danger -caption -fw-500 mt1"></p>
     </div>
     <div class="col col-4 py2 pl2">
       <label for="masked-fieldValues[debt-amount]" class="inline-block pb1 -fw-500">Amount</label>
@@ -38,6 +40,7 @@
         name="fieldValues[debt-amount]"
         :value="cleanedValue"
       />
+      <p class="-on-error -danger -caption -fw-500 mt1"></p>
     </div>
   </div>
 </template>

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -346,7 +346,8 @@ export default class DisputesInformationForm extends Widget {
     Object.keys(errors).forEach(key => {
       if (!this.ui[key]) return;
 
-      const parent = this.ui[key].parentNode;
+      // Select this each time to avoid dynamically added fields getting left out
+      const parent = this._getElementForKey(key).parentNode;
       let errorLabel = parent.querySelector('.-on-error');
 
       parent.classList.add('error');
@@ -399,7 +400,8 @@ export default class DisputesInformationForm extends Widget {
       /**
        * @type {HTMLInputElement}
        */
-      const element = this.ui[key];
+      // Select this each time to avoid dynamically added fields getting left out
+      const element = this._getElementForKey(key);
       if (element.dataset.customSelector) {
         data[key] = getCustomSelector(this.dispute, key).DOM();
       } else if (element) {
@@ -415,5 +417,9 @@ export default class DisputesInformationForm extends Widget {
     });
 
     return data;
+  }
+
+  _getElementForKey(key) {
+    return this.element.querySelector(`[for="fieldValues[${key}]"]`);
   }
 }

--- a/src/stylesheets/components/dispute-tools/TextModal.css
+++ b/src/stylesheets/components/dispute-tools/TextModal.css
@@ -1,7 +1,7 @@
 .Tools__Text-Modal {
   & h3,
   & strong {
-    color: var(--k-color-palette-accent);
+    color: var(--blue);
   }
 
   & h3 {

--- a/src/stylesheets/utils.css
+++ b/src/stylesheets/utils.css
@@ -214,23 +214,23 @@ h4.-h-sec > span {
 /* status colors */
 .-status {
   &-incomplete {
-    color: #f8e71c;
+    color: var(--orange);
   }
 
   &-completed {
-    color: #7ed321;
+    color: var(--red);
   }
 
   &-in-review {
-    color: #268aff;
+    color: var(--blue);
   }
 
   &-documents-sent {
-    color: #f04c34;
+    color: var(--purple);
   }
 
   &-update {
-    color: #50e3c2;
+    color: var(--green);
   }
 }
 

--- a/views/disputes/my.pug
+++ b/views/disputes/my.pug
@@ -22,31 +22,37 @@ block content
                 svg.mr1(width='11' height='11'): use(xlink:href='#svg-external')
                 | Go to my community profile
 
-          .-bg-neutral-dark.px3.pb2
-            .col.col-4.sm-col-12
+          if disputes.length > 0
+            .-bg-neutral-dark.px3.pb2
+              .col.col-4.sm-col-12
+                hr.mb3(aria-hidden="true")
+                h4.pb1 My disputes
+              ul.list-reset
+                each dispute in lodash.reverse(lodash.orderBy(disputes, d => lodash.get(lodash.head(d.statuses), 'updatedAt', d.updatedAt)))
+                  li
+                    - const latestStatus = lodash.head(dispute.statuses);
+                    a.block.clearfix.py1.mxn1(href=routeMappings.Disputes.show.url(dispute.id))
+                      .col.col-8.px1
+                        .-fw-600
+                          | #{dispute.disputeTool.name}
+                          if dispute.data.option !== 'none'
+                            |  / #{dispute.data.option}
+                      .col.col-4.px1.right-align
+                        - const latestStatusType = lodash.get(latestStatus, 'status', 'incomplete');
+                        .pt1.-caption.-ttu.-fw-600(
+                          class=`-status-${slugify(latestStatusType)}`
+                        )= latestStatusType
+                      .col.col-12.pl1
+                        .-caption.-ttu
+                          -
+                            // Ensure that if there's no status for some reason then we safely use the dispute's updated date
+                            const lastUpdated = lodash.get(latestStatus, 'updatedAt', lodash.get(dispute, 'updatedAt'));
+                          | #{moment(lastUpdated).format('MM-DD-YYYY hh:mm:ss a')}
+          else
+            .col.sm-col-12.text-center
               hr.mb3(aria-hidden="true")
-              h4.pb1 My disputes
-            ul.list-reset
-              each dispute in disputes
-                li
-                  - const latestStatus = lodash.head(dispute.statuses);
-                  a.block.clearfix.py1.mxn1(href=routeMappings.Disputes.show.url(dispute.id))
-                    .col.col-8.px1
-                      .-fw-600
-                        | #{dispute.disputeTool.name}
-                        if dispute.data.option !== 'none'
-                          |  / #{dispute.data.option}
-                    .col.col-4.px1.right-align
-                      - const latestStatusType = lodash.get(latestStatus, 'status', 'incomplete');
-                      .pt1.-caption.-ttu.-fw-600(
-                        class=`-status-${slugify(latestStatusType)}`
-                      )= latestStatusType
-                    .col.col-12.pl1
-                      .-caption.-ttu
-                        -
-                          // Ensure that if there's no status for some reason then we safely use the dispute's updated date
-                          const lastUpdated = lodash.get(latestStatus, 'updatedAt', lodash.get(dispute, 'updatedAt'));
-                        | #{moment(lastUpdated).format('MM-DD-YYYY hh:mm:ss a')}
+              h5 You currently do not have have any disputes.
+              h5.pt1 #[a(href="/dispute-tools") Click here] to begin filing your first dispute.
 
 block scripts
   script.

--- a/views/disputes/my.pug
+++ b/views/disputes/my.pug
@@ -39,6 +39,13 @@ block content
                       .pt1.-caption.-ttu.-fw-600(
                         class=`-status-${dispute.statuses[0].status.toLowerCase().replace(/\W/g, '-')}`
                       )= dispute.statuses[0].status
+                    .col.col-12.pl1
+                      .-caption.-ttu
+                        -
+                          const latestStatus = lodash.head(dispute.statuses);
+                          // Ensure that if there's no status for some reason then we safely use the dispute's updated date
+                          const lastUpdated = lodash.get(latestStatus, 'updatedAt', lodash.get(dispute, 'updatedAt'));
+                        | #{moment(lastUpdated).format('MM-DD-YYYY hh:mm:ss a')}
 
 block scripts
   script.

--- a/views/disputes/my.pug
+++ b/views/disputes/my.pug
@@ -29,6 +29,7 @@ block content
             ul.list-reset
               each dispute in disputes
                 li
+                  - const latestStatus = lodash.head(dispute.statuses);
                   a.block.clearfix.py1.mxn1(href=routeMappings.Disputes.show.url(dispute.id))
                     .col.col-8.px1
                       .-fw-600
@@ -36,13 +37,13 @@ block content
                         if dispute.data.option !== 'none'
                           |  / #{dispute.data.option}
                     .col.col-4.px1.right-align
+                      - const latestStatusType = lodash.get(latestStatus, 'status', 'incomplete');
                       .pt1.-caption.-ttu.-fw-600(
-                        class=`-status-${dispute.statuses[0].status.toLowerCase().replace(/\W/g, '-')}`
-                      )= dispute.statuses[0].status
+                        class=`-status-${slugify(latestStatusType)}`
+                      )= latestStatusType
                     .col.col-12.pl1
                       .-caption.-ttu
                         -
-                          const latestStatus = lodash.head(dispute.statuses);
                           // Ensure that if there's no status for some reason then we safely use the dispute's updated date
                           const lastUpdated = lodash.get(latestStatus, 'updatedAt', lodash.get(dispute, 'updatedAt'));
                         | #{moment(lastUpdated).format('MM-DD-YYYY hh:mm:ss a')}


### PR DESCRIPTION
This PR makes any dispute queries filter out deactivated disputes by default except when searching by 
dispute id https://github.com/debtcollective/parent/issues/180