### PR TITLE
using jessie instead of alpine for node docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM node:8.11.4-alpine
+FROM node:8.11.4
 
 WORKDIR /usr/src/app
 
-RUN apk --no-cache add build-base python git pdftk
+RUN apt-get update && apt-get install -y \
+  pdftk \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 


### PR DESCRIPTION
This PR brings back node-jessie to replace node-alpine. Looks like alpine has [issues with phantom](https://github.com/marcbachmann/node-html-pdf/issues/233#issuecomment-337308294). There's a workaround to install phantom directly but I prefer to use full one to not have these kind of issues later on.

This should close https://github.com/debtcollective/parent/issues/232