### PR TITLE
Fixing session login

### DIFF
--- a/controllers/SessionsController.js
+++ b/controllers/SessionsController.js
@@ -8,10 +8,6 @@ const BaseController = require('$lib/core/controllers/BaseController');
 const SessionsController = Class('SessionsController').inherits(BaseController)({
   prototype: {
     create(req, res) {
-      if (req.user) {
-        return res.redirect(config.router.helpers.root.url());
-      }
-
       return res.redirect(sso.buildRedirect(config.router.helpers.callback.url()));
     },
 

--- a/seeds/20171113114842_dispute_tools.js
+++ b/seeds/20171113114842_dispute_tools.js
@@ -49,7 +49,7 @@ This tool generates a dispute letter demanding that the creditor or collector se
 
 If you are not in default on the debt you wish to dispute, this tool will assist you to ask the creditor for the original contract or promissory note. If you are in default on the debt, this tool will assist you to demand that the collector send a series of documents called the "chain of title." If you are not sure whether or not you are in default, you can still use this dispute.
 
-Before you begin you will need the name and address of the creditor or the collector that is billing you. After you complete the dispute, you will receive a copy of the dispute by email which you can print and mail the yourself. You will also be given a chance to ask us to mail it for you. We also encourage all debt disputers to use our online system to report the responses you get from the collector. The more information we have about how creditors and collectors are responding to individual disputes, the better we can organize collectively against them.`,
+Before you begin you will need the name and address of the creditor or the collector that is billing you. After you complete the dispute, you will receive a copy of the dispute by email which you can print and mail yourself. You will also be given a chance to ask us to mail it for you. We also encourage all debt disputers to use our online system to report the responses you get from the collector. The more information we have about how creditors and collectors are responding to individual disputes, the better we can organize collectively against them.`,
     completed: 0,
   },
   {

--- a/tests/integration/controllers/SessionsControllerTest.js
+++ b/tests/integration/controllers/SessionsControllerTest.js
@@ -18,14 +18,14 @@ describe('SessionsController', () => {
     });
 
     describe('when authenticated', () => {
-      it('should redirect to root', async () => {
+      it('should redirect to discourse', async () => {
         const user = await createUser();
         const url = config.router.helpers.login.url();
         const req = testGetPage(url, user);
 
         return req.redirects(0).catch(({ status, response: { headers } }) => {
           expect(status).eq(302);
-          expect(headers.location).eq(config.router.helpers.root.url());
+          expect(headers.location.startsWith(config.sso.endpoint)).true;
         });
       });
     });

--- a/views/disputes/my.pug
+++ b/views/disputes/my.pug
@@ -37,7 +37,7 @@ block content
           else
             .col.sm-col-12.text-center
               hr.mb3(aria-hidden="true")
-              h5 You currently do not have have any disputes.
+              h5 You currently do not have any disputes.
               h5.pt1 #[a(href="/dispute-tools") Click here] to begin filing your first dispute.
 
 block scripts


### PR DESCRIPTION
This PR makes the `/login` endpoint to always redirect to Discourse. Fixes https://github.com/debtcollective/parent/issues/241

Also, fixes some small typos, one in the **Dispute Any Debt in Collections** tool description and other in the My Disputes `/disputes/my` page