### PR TITLE
showing 25 disputes instead of 5 in the admin dispute list

### DIFF
--- a/controllers/Admin/DisputesController.js
+++ b/controllers/Admin/DisputesController.js
@@ -55,7 +55,7 @@ Admin.DisputesController = Class(Admin, 'DisputesController').inherits(RestfulCo
               allowedFields: ['created_at', 'updated_at'],
             },
             paginate: {
-              pageSize: 5,
+              pageSize: 25,
             },
           })(req, res, next);
         });

--- a/src/javascripts/components/admin/disputes/AdminDisputesAddStatusForm.js
+++ b/src/javascripts/components/admin/disputes/AdminDisputesAddStatusForm.js
@@ -140,8 +140,8 @@ export default class AdminDisputesAddStatusForm extends Widget {
     this.formElement.action = this.constructor.updateUrlString.replace('${id}', dispute.id);
     this.userNameElement.textContent = dispute.user.safeName;
     this.disputeNameElement.textContent = disputeToolName;
-    // TODO Use Discourse provided profile image url
-    // this.userAvatarElement.src = dispute.user.imageURL;
+
+    this.userAvatarElement.src = dispute.user.avatarUrl || '/images/profile/placeholder-small.png';
 
     while (this.statusesWrapper.firstChild) {
       this.statusesWrapper.removeChild(this.statusesWrapper.firstChild);

--- a/src/stylesheets/_entries/admin/disputes/index.css
+++ b/src/stylesheets/_entries/admin/disputes/index.css
@@ -8,3 +8,7 @@ button[data-add-status] {
     opacity: 0.6;
   }
 }
+
+.profile-link {
+  line-height: 0;
+}

--- a/src/stylesheets/base_admin.css
+++ b/src/stylesheets/base_admin.css
@@ -58,5 +58,5 @@ tbody > tr {
 }
 
 tbody > tr > td {
-  padding: 10px;
+  padding: 5px 10px;
 }

--- a/views/admin/disputes/index.pug
+++ b/views/admin/disputes/index.pug
@@ -91,32 +91,28 @@ block content
 
       tbody
         each _dispute in disputes
-
           -
-            // add the user account image to be accessible on the front-end
+            var username = _dispute.user.username;
+            var discourseUrl = config.discourse.baseUrl;
+            var profileUrl = `${discourseUrl}/u/${username}`;
+
             _dispute.user.imageURL = '/images/profile/placeholder-small.png';
-
-            //- TODO Use Discourse provided profile image
-            //- if (_dispute.user.account.image.exists('small'))
-            //-   _dispute.user.account.imageURL = _dispute.user.account.image.urls['small'];
-
-            var displayName = "";
-            if (_dispute.data.forms) {
-              displayName = findDisplayName(_dispute.data.forms)
-            } else if (_dispute.data._forms) {
-              displayName = findDisplayName(_dispute.data._forms)
+            if (_dispute.user.avatarUrl) {
+              _dispute.user.imageURL = _dispute.user.avatarUrl;
             }
 
+            var displayName = "No Name"
+            if (_dispute.data.forms) {
+              displayName = findDisplayName(_dispute.data.forms);
+            } else if (_dispute.data._forms) {
+              displayName = findDisplayName(_dispute.data._forms);
+            }
           tr
             td
               .flex.items-center
-                img(src=_dispute.user.imageURL alt=(_dispute.user.safeName) width="50" height="50")
-                p.pl2
-                  .-fw-600= displayName
-                  .-fw-300.pl1
-                    span= "(by "
-                    span.-fw-400.-danger= _dispute.user.safeName
-                    span= ")"
+                a(href=profileUrl target="_blank" title=username class="profile-link")
+                  img(src=_dispute.user.imageURL width="50" height="50")
+                .pl2.-fw-600= displayName
             td.-fw-400
               | #{_dispute.readableId}
             td.-fw-500


### PR DESCRIPTION
This PR changes the dispute admin list to show more items per page, from 5 to 25. Also, makes some changes on how we display data on the table so it doesn't have a new line

## Attachments

![image](https://user-images.githubusercontent.com/849872/47247844-a7b0be00-d3cb-11e8-8536-0312d18810e3.png)