### PR TITLE
adding startDispute get to redirect after login

### DIFF
--- a/config/RouteMappings.js
+++ b/config/RouteMappings.js
@@ -137,6 +137,11 @@ const routeMappings = RouteMappings()
     as: 'root',
   })
 
+  .get('/:id/start', {
+    to: 'DisputeTools#startDispute',
+    as: 'startDispute',
+  })
+
   .get('/:id', {
     to: 'DisputeTools#show',
     as: 'tool',

--- a/controllers/DisputeToolsController.js
+++ b/controllers/DisputeToolsController.js
@@ -1,13 +1,21 @@
 /* globals Class */
 const marked = require('marked');
+const Dispute = require('$models/Dispute');
 const DisputeTool = require('$models/DisputeTool');
-const { NotFoundError } = require('$lib/errors');
+const { BadRequest, NotFoundError } = require('$lib/errors');
 const RestfulController = require('$lib/core/controllers/RestfulController');
+const config = require('$config/config');
+
+const { authenticate } = require('$services/auth');
 
 const idRegex = /^1{8}-1{4}-[12346]{4}-1{4}-1{12}$/;
 
 const DisputeToolsController = Class('DisputeToolsController').inherits(RestfulController)({
   beforeActions: [
+    {
+      before: [authenticate],
+      actions: ['startDispute'],
+    },
     {
       before: [
         async (req, res, next) => {
@@ -27,7 +35,7 @@ const DisputeToolsController = Class('DisputeToolsController').inherits(RestfulC
           }
         },
       ],
-      actions: ['show'],
+      actions: ['show', 'startDispute'],
     },
   ],
   prototype: {
@@ -80,6 +88,26 @@ const DisputeToolsController = Class('DisputeToolsController').inherits(RestfulC
 
     dtr(req, res) {
       res.render('home/dtr.pug');
+    },
+
+    async startDispute(req, res, next) {
+      const disputeTool = res.locals.disputeTool;
+
+      if (!req.query.option) {
+        return next(new BadRequest());
+      }
+
+      try {
+        const dispute = await Dispute.createFromTool({
+          user: req.user,
+          disputeToolId: disputeTool.id,
+          option: req.query.option,
+        });
+
+        res.redirect(config.router.helpers.Disputes.show.url(dispute.id));
+      } catch (e) {
+        next(e);
+      }
     },
   },
 });

--- a/controllers/SessionsController.js
+++ b/controllers/SessionsController.js
@@ -46,6 +46,12 @@ const SessionsController = Class('SessionsController').inherits(BaseController)(
           }
 
           return req.session.save(() => {
+            const redirectTo =
+              req.session.redirectTo || config.router.mappings.Disputes.myDisputes.url();
+
+            // remove redirectTo
+            req.session.redirectTo = '';
+
             Raven.setContext({
               user: {
                 email: user.email,
@@ -54,7 +60,7 @@ const SessionsController = Class('SessionsController').inherits(BaseController)(
               },
             });
 
-            res.redirect(config.router.mappings.Disputes.myDisputes.url());
+            res.redirect(redirectTo);
           });
         });
       })(req, res, next);

--- a/services/auth/authentication.js
+++ b/services/auth/authentication.js
@@ -1,22 +1,16 @@
 const config = require('$config/config');
 
 /**
- * This service closely matches the middleware {@link handleAuthentication}.
- * While the authentication middleware's responsibility is to ensure that
- * `req.user` is populated as early as possible (when possible), it does not
- * ensure that a user is authenticated before accessing a route. In the interest
- * of easy-to-understand permission policies, this service can be injected using
- * the `beforeActions` directive on a controller. It will force the requester to
- * authenticate before continuing the route. It will only work on GETs as the
- * redirect back will be a GET. This is unavoidable. Fortunately, the way the
- * platform is currently written this isn't actually a big problem as we will
- * not have any situations where a requester will be performing any other method
- * than GET as their first pass at an authenticate route.
+ * Redirects to login if there's no authenticated in user
+ * Saves req.url to redirect after login
  */
 module.exports = async (req, res, next) => {
   if (!req.user) {
     res.format({
       html() {
+        // save redirectTo
+        req.session.redirectTo = req.url;
+
         return res.redirect(config.router.mappings.login.url());
       },
       json() {

--- a/views/dispute-tools/show-optionless.pug
+++ b/views/dispute-tools/show-optionless.pug
@@ -12,18 +12,11 @@ block content
 
       .col.lg-col-9.col-12.px2
         .Tool__Optionless.pt3.pr3.pl3.pb2.-bg-neutral-dark
-          form(
-            action=routeMappings.Disputes.create.url()
-            method="post"
-          )
-            input(name="disputeToolId" type="hidden" value=disputeTool.id)
-            input(name="option" type="hidden" value="none")
+          .Tool__Optionless__Content.pb3
+            h4.pb2 We #[span ❤] debt resisters. Let's get this dispute started!
+            != marked(disputeTool.about)
 
-            .Tool__Optionless__Content.pb3
-              h4.pb2 We #[span ❤] debt resisters. Let's get this dispute started!
-              != marked(disputeTool.about)
-
-            button.-k-btn.btn-primary.-fw.-fw-600(type="submit") Start Dispute
+          a.-k-btn.btn-primary.-fw.-fw-600(href=`${routeMappings.startDispute.url(disputeTool.id)}?option=none`) Start Dispute
 
 block scripts
   script.

--- a/views/dispute-tools/show.pug
+++ b/views/dispute-tools/show.pug
@@ -4,21 +4,15 @@ block title
   | #{disputeTool.name} — The Debt Collective
 
 block content
-  mixin DisputeCard(key, dispute)
+  mixin DisputeCard(option, dispute)
     .col.md-col-6.col-12.p2
-      form.Tool__DisputeCard.flex.flex-column.rounded.-fh(
-        action=routeMappings.Disputes.create.url()
-        method="POST"
-      )
-        input(name="disputeToolId" type="hidden" value=disputeTool.id)
-        input(name="option" type="hidden" value=key)
-
+      .Tool__DisputeCard.flex.flex-column.rounded.-fh
         .flex-auto.pb3
-          h2= key
+          h2= option
           p.pb2.-fw-600= dispute.title
           p.pb2!= dispute.description
 
-        button.-k-btn.btn-primary.-fw.-fw-600(type="submit") This is my situation
+        a.-k-btn.btn-primary.-fw.-fw-600(href=`${routeMappings.startDispute.url(disputeTool.id)}?option=${option}`) Start Dispute
 
   .wrapper.px2.py3
     .clearfix.mxn2
@@ -38,14 +32,7 @@ block content
               each val, key in disputeTool.data.options
                 +DisputeCard(key, val)
           else
-            form(
-              action=routeMappings.Disputes.create.url()
-              method="post"
-            )
-              input(name="disputeToolId" type="hidden" value=disputeTool.id)
-              input(name="option" type="hidden" value="none")
-
-              button.-k-btn.btn-primary.-fw.-fw-600(type="submit") Start Dispute
+            a.-k-btn.btn-primary.-fw.-fw-600(href=`${routeMappings.startDispute.url(disputeTool.id)}?option=none`) Start Dispute
 
 block append body
   each option, key in disputeTool.data.options

--- a/views/shared/400.pug
+++ b/views/shared/400.pug
@@ -1,0 +1,21 @@
+extends ../layouts/shared.pug
+
+block title
+  | 400 — The Debt Collective
+
+block content
+  .max-width-3.mx-auto.py4
+    .clearfix.flex.items-center
+      .col.md-col-6.col-12.center
+        img(src='/images/global/tdc-hand.png')
+      .col.md-col-6.col-12
+        h2.pb3.-ttu.-h-sec: span 400
+        h4.pb2.-ff-sec.-fw-300 Looks like you followed a bad link or something went wrong.
+        p
+          a.button-clear.-fw-600(href='/')
+            svg(width='14' height='14'): use(xlink:href='#svg-arrow-backward')
+            span.pl1 Go to homepage.
+
+        if showLogin
+          p.pt3
+            button.-k-btn.btn-primary.-fw.-fw-600.js-login-link Login


### PR DESCRIPTION
- Add `redirectTo` functionality to login.
- Adding `startDispute` route, to allow get requests to create a Dispute. This is used with `redirectTo` to allow redirect to a new dispute after login

Closes debtcollective/parent#252

## Attachments

[Video](https://monosnap.com/file/1vS4OBlWbmJ0feG8GUSYp04pmVtgns)