### PR TITLE
'New' status for Disputes, creating discourse thread when the status is Incomplete

### DIFF
--- a/controllers/DisputesController.js
+++ b/controllers/DisputesController.js
@@ -167,27 +167,28 @@ const DisputesController = Class('DisputesController').inherits(RestfulControlle
         });
       }
 
-      return dispute
-        .save()
-        .then(() => {
-          // After the first save with data, we mark the Dispute as incompleted
-          if (dispute.isNew() && !dispute.isEmpty()) {
-            dispute.markAsIncompleted();
-          }
+      try {
+        await dispute.save();
 
-          return res.format({
-            html() {
-              if (req.body.command === 'setForm') {
-                req.flash('success', 'Your information was successfully updated');
-              }
-              return res.redirect(config.router.helpers.Disputes.show.url(dispute.id));
-            },
-            json() {
-              return res.json({ status: 'confirmed', dispute });
-            },
-          });
-        })
-        .catch(next);
+        // After the first save with data, we mark the Dispute as incompleted
+        if (dispute.isNew() && !dispute.isEmpty()) {
+          await dispute.markAsIncompleted();
+        }
+
+        return res.format({
+          html() {
+            if (req.body.command === 'setForm') {
+              req.flash('success', 'Your information was successfully updated');
+            }
+            return res.redirect(config.router.helpers.Disputes.show.url(dispute.id));
+          },
+          json() {
+            return res.json({ status: 'confirmed', dispute });
+          },
+        });
+      } catch (e) {
+        next(e);
+      }
     },
 
     setSignature(req, res, next) {

--- a/controllers/DisputesController.js
+++ b/controllers/DisputesController.js
@@ -169,8 +169,13 @@ const DisputesController = Class('DisputesController').inherits(RestfulControlle
 
       return dispute
         .save()
-        .then(() =>
-          res.format({
+        .then(() => {
+          // After the first save with data, we mark the Dispute as incompleted
+          if (dispute.isNew() && !dispute.isEmpty()) {
+            dispute.markAsIncompleted();
+          }
+
+          return res.format({
             html() {
               if (req.body.command === 'setForm') {
                 req.flash('success', 'Your information was successfully updated');
@@ -180,8 +185,8 @@ const DisputesController = Class('DisputesController').inherits(RestfulControlle
             json() {
               return res.json({ status: 'confirmed', dispute });
             },
-          }),
-        )
+          });
+        })
         .catch(next);
     },
 

--- a/models/Dispute.js
+++ b/models/Dispute.js
@@ -137,7 +137,7 @@ const Dispute = Class('Dispute')
     });
 
     const status = new DisputeStatus({
-      status: 'Incomplete',
+      status: 'New',
     });
 
     const disputeTool = await DisputeTool.findById(disputeToolId);
@@ -244,6 +244,39 @@ const Dispute = Class('Dispute')
           .then(resolve)
           .catch(reject);
       });
+    },
+
+    /**
+     * Moves the dispute into the incompleted status.
+     * This method can only be called if the Dispute has New as status
+     *
+     * @param {boolean} saved returns true if the status was changed correctly, false otherwise
+     */
+    async markAsIncompleted() {
+      if (!this.isNew()) {
+        return false;
+      }
+
+      // create incomplete status and persist
+      const incompleteStatus = new DisputeStatus({
+        status: 'Incomplete',
+        disputeId: this.id,
+      });
+
+      await incompleteStatus.save();
+
+      return true;
+    },
+
+    /**
+     * returns true if the dispute status is equal to 'New'
+     *
+     * @param {boolean} isNew true if dispute status is equal to 'New'
+     */
+    isNew() {
+      const status = _.first(this.statuses);
+
+      return status.status === 'New';
     },
 
     /**

--- a/shared/enum/DisputeStatuses.js
+++ b/shared/enum/DisputeStatuses.js
@@ -1,4 +1,5 @@
 module.exports = Object.freeze({
+  new: 'New',
   incomplete: 'Incomplete',
   completed: 'Completed',
   inReview: 'In Review',

--- a/tests/integration/controllers/DisputesControllerTest.js
+++ b/tests/integration/controllers/DisputesControllerTest.js
@@ -124,11 +124,11 @@ describe('DisputesController', () => {
     };
     const setFormBody = {
       command: 'setForm',
-      name: 'the-form',
+      formName: 'personal-information-form',
       fieldValues: {
-        name: 'name',
-        address1: 'address 1 street',
+        name: 'Orlando Del Aguila',
       },
+      _isDirty: true,
     };
 
     before(async () => {
@@ -159,30 +159,23 @@ describe('DisputesController', () => {
       });
     });
 
-    describe('after first save', () => {
+    describe('first update', () => {
       before(async () => {});
 
       it('should set status to incomplete', async () => {
         let dispute = await createDispute(owner);
         let status = _.first(dispute.statuses);
         const url = urls.Disputes.updateDisputeData.url(dispute.id);
-        const setFormBody = {
-          command: 'setForm',
-          name: 'personal-form',
-          fieldValues: {
-            name: 'name',
-            address1: 'address 1 street',
-          },
-        };
 
         // check dispute status is new
         expect(status.status).eql('New');
 
         // make a request to update the form
-        testPutPage(url, setFormBody, owner);
+        await testPutPage(url, setFormBody, owner);
 
         // reload dispute
-        dispute = Dispute.findById(dispute.id);
+        dispute = await Dispute.findById(dispute.id);
+        expect(dispute.statuses.length).eql(2);
         status = _.first(dispute.statuses);
 
         // check dispute status is incomplete

--- a/tests/unit/models/Dispute.js
+++ b/tests/unit/models/Dispute.js
@@ -84,7 +84,7 @@ describe('Dispute', () => {
     it('should create a dispute with a default status', async () => {
       const statuses = await DisputeStatus.query().where('dispute_id', dispute.id);
       expect(statuses.length).eq(1);
-      expect(statuses[0].status).eq(DisputeStatuses.incomplete);
+      expect(statuses[0].status).eq(DisputeStatuses.new);
     });
 
     it('should create the dispute and save a new discourse topic thread id', async () => {

--- a/tests/unit/models/Dispute.js
+++ b/tests/unit/models/Dispute.js
@@ -8,10 +8,6 @@ const DisputeStatus = require('$models/DisputeStatus');
 const Dispute = require('$models/Dispute');
 const DisputeTool = require('$models/DisputeTool');
 const { discourse } = require('$lib');
-const {
-  discourse: { baseUrl: discourseEndpoint },
-} = require('$config/config');
-
 const { createUser, createDispute, truncate } = require('$tests/utils');
 const { wageGarnishmentDisputes } = require('$tests/utils/sampleDisputeData');
 
@@ -22,17 +18,6 @@ describe('Dispute', () => {
   before(async () => {
     user = await createUser();
     tool = await DisputeTool.first();
-  });
-
-  describe('processors', () => {
-    it('should add the disputeThreadLink', async () => {
-      const dispute = await createDispute(user);
-
-      await expect(Dispute.findById(dispute.id)).to.eventually.have.property(
-        'disputeThreadLink',
-        `${discourseEndpoint}/t/${dispute.disputeThreadId}`,
-      );
-    });
   });
 
   describe('findById', () => {
@@ -85,10 +70,6 @@ describe('Dispute', () => {
       const statuses = await DisputeStatus.query().where('dispute_id', dispute.id);
       expect(statuses.length).eq(1);
       expect(statuses[0].status).eq(DisputeStatuses.new);
-    });
-
-    it('should create the dispute and save a new discourse topic thread id', async () => {
-      expect(dispute.disputeThreadId).not.undefined;
     });
   });
 


### PR DESCRIPTION
This PR adds the **New** status for Disputes, this will be the new default status.

When a User saves some data in the Dispute (either by clicking **Save for later** or by completing a form), we will change the status to **Incomplete** and create the Discourse thread at that moment.

Closes debtcollective/parent#251

## Attachments

![image](https://user-images.githubusercontent.com/849872/50127615-83405900-0237-11e9-88a7-98aa551d842e.png)