### PR TITLE
Add optional argument to build script to be able to run in dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,4 @@ config:
 	cp config/knexfile.sample.js knexfile.js
 
 project:
-	yarn &&
-	yarn utils:resetdb &&
-	yarn db:migrate &&
-	yarn db:seed &&
-	yarn build
+	yarn && yarn utils:resetdb && yarn db:migrate && yarn db:seed && yarn build

--- a/scripts/build
+++ b/scripts/build
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 
-export NODE_ENV=production
+ENV=${1:-production}
+
+echo 'Build running with' ${ENV} 'environment'
+echo 'Add one option value to this command to change environment'
+
+export NODE_ENV=ENV
 npx rimraf public/build
 
 yarn svg


### PR DESCRIPTION
While this still not the ideal case, this code adds a minimal update to the `build` command to allow devs to run build in development mode _(allowing set breakpoints for development process)_

# Note

The workflow to develop should be improved by:
- Adding documentation on "How is the inteded workflow for the development of this project"
or
- Add a new webpack configuration in order to allow "typical development workflow" _(Having hot reload and ability to set breakpoints on the application)_