### PR TITLE
Fix InformationForm validation

### DIFF
--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -380,20 +380,23 @@ export default class DisputesInformationForm extends Widget {
       if (!this.ui[key]) return;
 
       // Select this each time to avoid dynamically added fields getting left out
-      const parent = this._getElementForKey(key).parentNode;
-      let errorLabel = parent.querySelector('.-on-error');
+      this._getElementsForKey(key).forEach(element => {
+        const parent = element.parentNode;
 
-      parent.classList.add('error');
+        let errorLabel = parent.querySelector('.-on-error');
 
-      if (errorLabel) {
-        errorLabel.innerText = `▲ ${errors[key].message}`;
-        return;
-      }
+        parent.classList.add('error');
 
-      errorLabel = parent.nextSibling;
-      if (errorLabel && errorLabel.classList.contains('-on-error')) {
-        errorLabel.innerText = `▲ ${errors[key].message}`;
-      }
+        if (errorLabel) {
+          errorLabel.innerText = `▲ ${errors[key].message}`;
+          return;
+        }
+
+        errorLabel = parent.nextSibling;
+        if (errorLabel && errorLabel.classList.contains('-on-error')) {
+          errorLabel.innerText = `▲ ${errors[key].message}`;
+        }
+      });
     });
 
     const firstErrorKey = Object.keys(errors)[0];
@@ -434,35 +437,39 @@ export default class DisputesInformationForm extends Widget {
        * @type {HTMLInputElement}
        */
       // Select this each time to avoid dynamically added fields getting left out
-      const element = this._getElementForKey(key);
+      this._getElementsForKey(key).forEach(element => {
+        if (!element) {
+          return;
+        }
 
-      if (!element) {
-        return;
-      }
+        if (element.dataset.customSelector) {
+          data[key] = getCustomSelector(this.dispute, key).DOM();
+          return;
+        }
 
-      if (element.dataset.customSelector) {
-        data[key] = getCustomSelector(this.dispute, key).DOM();
-        return;
-      }
+        switch (element.type) {
+          case 'radio':
+            val = document.querySelector(`[name="${element.name}"]:checked`).value;
+            break;
+          case 'checkbox':
+            val = element.checked === true ? 'yes' : 'no';
+            break;
+          default:
+            val = element.value;
+        }
 
-      switch (element.type) {
-        case 'radio':
-          val = document.querySelector(`[name="${element.name}"]:checked`).value;
-          break;
-        case 'checkbox':
-          val = element.checked === true ? 'yes' : 'no';
-          break;
-        default:
-          val = element.value;
-      }
-
-      data[key] = val;
+        if (data[key]) {
+          data[key] = _.castArray(data[key]).concat(val);
+        } else {
+          data[key] = val;
+        }
+      });
     });
 
     return data;
   }
 
-  _getElementForKey(key) {
-    return this.element.querySelector(`[name^="fieldValues[${key}]"]`);
+  _getElementsForKey(key) {
+    return this.element.querySelectorAll(`[name^="fieldValues[${key}]"]:not([type="hidden"])`);
   }
 }

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -435,24 +435,34 @@ export default class DisputesInformationForm extends Widget {
        */
       // Select this each time to avoid dynamically added fields getting left out
       const element = this._getElementForKey(key);
+
+      if (!element) {
+        return;
+      }
+
       if (element.dataset.customSelector) {
         data[key] = getCustomSelector(this.dispute, key).DOM();
-      } else if (element) {
-        if (element.type === 'radio') {
-          val = document.querySelector(`[name="${element.name}"]:checked`).value;
-        } else if (element.type === 'checkbox') {
-          val = element.checked === true ? 'yes' : 'no';
-        } else {
-          val = element.value;
-        }
-        data[key] = val;
+        return;
       }
+
+      switch (element.type) {
+        case 'radio':
+          val = document.querySelector(`[name="${element.name}"]:checked`).value;
+          break;
+        case 'checkbox':
+          val = element.checked === true ? 'yes' : 'no';
+          break;
+        default:
+          val = element.value;
+      }
+
+      data[key] = val;
     });
 
     return data;
   }
 
   _getElementForKey(key) {
-    return this.element.querySelector(`[for="fieldValues[${key}]"]`);
+    return this.element.querySelector(`[name^="fieldValues[${key}]"]`);
   }
 }

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -449,20 +449,25 @@ export default class DisputesInformationForm extends Widget {
 
         switch (element.type) {
           case 'radio':
-            val = document.querySelector(`[name="${element.name}"]:checked`).value;
+            val = element.checked ? element.value : null;
             break;
           case 'checkbox':
-            val = element.checked === true ? 'yes' : 'no';
+            val = element.checked ? 'yes' : 'no';
             break;
           default:
             val = element.value;
         }
 
+        if (!val) {
+          return;
+        }
+
         if (data[key]) {
           data[key] = _.castArray(data[key]).concat(val);
-        } else {
-          data[key] = val;
+          return;
         }
+
+        data[key] = val;
       });
 
       if (_.includes(this.constraints[key], 'array')) {

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -464,6 +464,10 @@ export default class DisputesInformationForm extends Widget {
           data[key] = val;
         }
       });
+
+      if (_.includes(this.constraints[key], 'array')) {
+        data[key] = _.castArray(data[key]);
+      }
     });
 
     return data;


### PR DESCRIPTION
The current validation flow of our forms used to not run as a cause of a bad way to traverse elements within the form, besides, the flow itself needed some updates in order to handle properly dynamic fields generated in some forms and updates for handle radio inputs properly.

Closes #109 

# Media
_As the video is short look for sec 2 where the error is being thrown, besides, notice that despite the error the form is being submitted_
http://recordit.co/cNPvdrP9h8

_Now after the fix_
http://recordit.co/k7JSBGReHw

Another issue that has been solved around this scope is exposed below:
_Before this PR "Dispute your wages being taken" option A throws an error that crash the app if SSN wasn't valid_
http://recordit.co/nYhCSL4c3f

_Now after the fix, it shows error properly_
http://recordit.co/XgKjzKbK7H

## Disclaimer
The forms have been tested manually, but ideally we should have some integration test for each of them, the current test suite includes some test for forms but they supposed to be green, nevertheless, we do have some failing tests out of the box _(extra documentation may be needed to config database for testing)_.