### PR TITLE
[WIP] Prevent ViewDisputeToolsIndex for being used when not available

### DIFF
--- a/views/dispute-tools/index.pug
+++ b/views/dispute-tools/index.pug
@@ -137,5 +137,10 @@ block scripts
         disputeIds: !{JSON.stringify(disputeIds)}
       };
 
-      new ViewDisputeToolsIndex(options);
+      //- If ViewDisputeToolsIndex is not available is very likely that something wrong happen when building the app
+      if (window.ViewDisputeToolsIndex) {
+        new ViewDisputeToolsIndex(options);
+      } else {
+        console.warn('ViewDisputeToolsIndex class is not available');
+      }
     }, true);


### PR DESCRIPTION
fix(view/dispute-tools): Check ViewDisputeToolsIndex availability before trying to use it

While this code will prevent the error to happen the real cause of the problem is that currently we have two issues (#114 and #115) that make the app unable to build as expected, thus, by checking the availability of the `class ViewDisputeToolsIndex` we will prevent to raise a new error.

If the `ViewDisputeToolsIndex` is not available the page will render but all the scripts at `src/javascripts/_entries/dispute-tools/index.js` won't be able to run.

Closes #113 