### PR TITLE
fix(Field): Prevent fatal error on getAttributesFromValidations

### DIFF
--- a/lib/data/form-definitions/validations.js
+++ b/lib/data/form-definitions/validations.js
@@ -161,9 +161,17 @@ class Field {
 
   static getAttributesFromValidations(validations, attributes = {}) {
     return validations.reduce((attrs, validation) => {
+      if (typeof validation !== 'string') {
+        // eslint-disable-next-line
+        console.warn('Trying to add attributes over invalid validations');
+        return attrs;
+      }
+
       if (validation.startsWith('maxLength')) {
         return Object.assign({ maxlength: validation.split(':')[1] }, attrs);
-      } else if (validation.startsWith('minLength')) {
+      }
+
+      if (validation.startsWith('minLength')) {
         return Object.assign({ minlength: validation.split(':')[1] }, attrs);
       }
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "body-parser": "^1.15.2",
     "caniuse-db": "^1.0.30000784",
     "caniuse-lite": "^1.0.30000697",
+    "chai-spies": "^1.0.0",
     "checkit": "^0.7.0",
     "chokidar": "^2.0.0",
     "cli-table": "^0.3.1",

--- a/tests/form-validations/Field.test.js
+++ b/tests/form-validations/Field.test.js
@@ -1,5 +1,10 @@
-const { expect } = require('chai');
+const chai = require('chai');
+const spies = require('chai-spies');
 const Field = require('$form-definitions/validations');
+
+chai.use(spies);
+
+const expect = chai.expect;
 
 describe('Field', () => {
   describe('constructor', () => {
@@ -95,6 +100,42 @@ describe('Field', () => {
           const f = new Field({ validations: fv, attributes: { hello: 'world' } });
           expect(f.attributes).include({ hello: 'world', ...fv.attributes });
         });
+      });
+    });
+  });
+
+  describe('getAttributesFromValidations', () => {
+    it('returns maxLength attribute', () => {
+      const validations = ['required', 'maxLength:256'];
+
+      expect(Field.getAttributesFromValidations(validations, {})).to.deep.equal({
+        maxlength: '256',
+      });
+    });
+
+    it('returns minLength attribute', () => {
+      const validations = ['required', 'minLength:256'];
+
+      expect(Field.getAttributesFromValidations(validations, {})).to.deep.equal({
+        minlength: '256',
+      });
+    });
+
+    describe('when no validations to add', () => {
+      it('returns empty object', () => {
+        const validations = [];
+
+        expect(Field.getAttributesFromValidations(validations, {})).to.deep.equal({});
+      });
+    });
+
+    describe('when unexpected validations format', () => {
+      it('returns empty object', () => {
+        const spy = chai.spy.on(console, 'warn', msg => msg);
+        const validations = [{ rule: 'foo' }];
+
+        expect(Field.getAttributesFromValidations(validations, {})).to.deep.equal({});
+        expect(spy).to.have.been.called();
       });
     });
   });

--- a/tests/unit/services/renderTests.js
+++ b/tests/unit/services/renderTests.js
@@ -1,8 +1,8 @@
 const pdftk = require('node-pdftk');
 const moment = require('moment');
 const { expect } = require('chai');
-const { render } = require('../../../services/render');
-const { getConfiguration } = require('../../../services/disputeToolConfigurations');
+const { render } = require('$services/render');
+const { getConfiguration } = require('$services/disputeToolConfigurations');
 const {
   generalDebtDispute,
   privateStudentLoanDispute: { notDefaulted: pslNotDefaulted, defaulted: pslDefaulted },
@@ -14,7 +14,7 @@ const { extractPdfText } = require('../../utils');
 const {
   formatDate,
   normalizeSsn,
-} = require('../../../services/renderers/tool-configurations/shared/utils');
+} = require('$services/renderers/tool-configurations/shared/utils');
 const { doeDisclosure } = require('../../../config/config');
 
 function basicRenderTest(sampleData, docTemplates = [1]) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,6 +2167,11 @@ chai-as-promised@^7.1.1:
   dependencies:
     check-error "^1.0.2"
 
+chai-spies@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chai-spies/-/chai-spies-1.0.0.tgz#d16b39336fb316d03abf8c375feb23c0c8bb163d"
+  integrity sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==
+
 chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"


### PR DESCRIPTION
The method of getAttributesFromValidations may receive inputs that don't belong to any of the
defined cases within, thus, those cases will throw an unexpected error that makes the whole flow
crash. This commit adds some tests cases to monitor and support unexpected entries.

Closes #117 