### PR TITLE
Prevent invalid signature of defineProperty on "mix" function usage

### DIFF
--- a/src/javascripts/lib/widget/Utils.js
+++ b/src/javascripts/lib/widget/Utils.js
@@ -12,8 +12,8 @@ export default function mix(...modules) {
 
   modules.map(module =>
     Object.getOwnPropertyNames(module.prototype).map(key => {
-      if (key !== 'constructor' && key !== 'name') {
-        desc = Object.getOwnPropertyDescriptor(module.prototype, key);
+      desc = Object.getOwnPropertyDescriptor(module.prototype, key);
+      if (key !== 'constructor' && key !== 'name' && desc) {
         Object.defineProperty(_Mix.prototype, key, desc);
       }
       return undefined;


### PR DESCRIPTION
Move the getOwnPropertyDescriptor statement to prevent undefined description when using the defineProperty method.

# Note
I have tried to reproduce the issue on iPhone using Safari mobile browser and even add tests in order to see if I was able to trigger the issue, nevertheless, I could not reproduce it. On the other hand, the code on this PR will Inevitably prevent the defineProperty signature from failing by making sure all the arguments are defined.