### PR TITLE
refactor(Views): Add short-circuit evaluation for View class usage

### DIFF
--- a/views/admin/disputes/index.pug
+++ b/views/admin/disputes/index.pug
@@ -192,5 +192,12 @@ block scripts
         isAdmin: true,
       };
 
-      new ViewAdminDisputesIndex(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewAdminDisputesIndex) {
+        new ViewAdminDisputesIndex(options);
+      } else {
+        const message = 'ViewAdminDisputesIndex class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/admin/disputes/show.pug
+++ b/views/admin/disputes/show.pug
@@ -24,5 +24,12 @@ block scripts
         dispute: !{JSON.stringify(dispute)},
       };
 
-      new ViewAdminDisputesShow(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewAdminDisputesShow) {
+        new ViewAdminDisputesShow(options);
+      } else {
+        const message = 'ViewAdminDisputesShow class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/dispute-tools/index.pug
+++ b/views/dispute-tools/index.pug
@@ -137,5 +137,12 @@ block scripts
         disputeIds: !{JSON.stringify(disputeIds)}
       };
 
-      new ViewDisputeToolsIndex(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewDisputeToolsIndex) {
+        new ViewDisputeToolsIndex(options);
+      } else {
+        const message = 'ViewDisputeToolsIndex class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/dispute-tools/show-optionless.pug
+++ b/views/dispute-tools/show-optionless.pug
@@ -27,5 +27,12 @@ block scripts
         options: !{JSON.stringify(disputeTool.data.options)},
       };
 
-      new ViewDisputeToolsShow(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewDisputeToolsShow) {
+        new ViewDisputeToolsShow(options);
+      } else {
+        const message = 'ViewDisputeToolsShow class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/dispute-tools/show.pug
+++ b/views/dispute-tools/show.pug
@@ -57,5 +57,12 @@ block scripts
         options: !{JSON.stringify(disputeTool.data.options)},
       };
 
-      new ViewDisputeToolsShow(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewDisputeToolsShow) {
+        new ViewDisputeToolsShow(options);
+      } else {
+        const message = 'ViewDisputeToolsShow class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/disputes/my.pug
+++ b/views/disputes/my.pug
@@ -52,5 +52,12 @@ block scripts
         currentURL: !{JSON.stringify(currentURL)},
       };
 
-      new ViewDefault(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewDefault) {
+        new ViewDefault(options);
+      } else {
+        const message = 'ViewDefault class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/disputes/show.pug
+++ b/views/disputes/show.pug
@@ -86,5 +86,12 @@ block scripts
         currentStep: !{JSON.stringify(currentStep)},
       };
 
-      new ViewDisputesShow(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewDisputesShow) {
+        new ViewDisputesShow(options);
+      } else {
+        const message = 'ViewDisputesShow class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/disputes/showForVisitor.pug
+++ b/views/disputes/showForVisitor.pug
@@ -33,5 +33,12 @@ block scripts
         currentURL: !{JSON.stringify(currentURL)},
       };
 
-      new ViewDisputesShowForVisitors(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewDisputesShowForVisitors) {
+        new ViewDisputesShowForVisitors(options);
+      } else {
+        const message = 'ViewDisputesShowForVisitors class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/home/contact.pug
+++ b/views/home/contact.pug
@@ -43,5 +43,13 @@ block scripts
         currentUser: !{JSON.stringify(UserRenderer(currentUser))},
         currentURL: !{JSON.stringify(currentURL)},
       };
-      new ViewHomeContact(options);
+
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewHomeContact) {
+        new ViewHomeContact(options);
+      } else {
+        const message = 'ViewHomeContact class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/home/index.pug
+++ b/views/home/index.pug
@@ -23,5 +23,12 @@ block scripts
         currentURL: !{JSON.stringify(currentURL)},
       };
 
-      new ViewHomeIndex(options);
+      //- If class is not available is likely that something wrong happen with build process
+      if (window.ViewHomeIndex) {
+        new ViewHomeIndex(options);
+      } else {
+        const message = 'ViewHomeIndex class is not available';
+        console.warn(message);
+        window.Sentry && Sentry.captureMessage(message);
+      }
     }, true);

--- a/views/layouts/shared.pug
+++ b/views/layouts/shared.pug
@@ -36,5 +36,12 @@ html(lang='en')
           currentURL: !{JSON.stringify(currentURL)},
         };
 
-        new ViewDefault(options);
+        //- If class is not available is likely that something wrong happen with build process
+        if (window.ViewDefault) {
+          new ViewDefault(options);
+        } else {
+          const message = 'ViewDefault class is not available';
+          console.warn(message);
+          window.Sentry && Sentry.captureMessage(message);
+        }
       }, true);


### PR DESCRIPTION
To attach some JS behavior to views the code currently instantiate classes, those classes should
always be available unless there are some build process error (or something that at this point is
unknown) this code avoid to trigger errors to sentry but instead a friendly notification as if this
happens the problem is likely to be somewhere else.

Closes #113 
Closes #124 
Closes #126 