### PR TITLE
refactor(DonationFLow): Update HTML for final preview only when view is about to render

### DIFF
--- a/src/javascripts/components/DonationFlow.js
+++ b/src/javascripts/components/DonationFlow.js
@@ -75,7 +75,15 @@ export default class DonationFlow extends Widget {
     // Continue button
     this.sectionDonateSubmitEl.addEventListener('click', () => {
       const { amount } = this.state;
-      if (amount) this.setState({ page: PAGE_PAYMENT });
+
+      if (amount) {
+        // Edit HTML for preview amount before final payment
+        this.sectionDonateValues.forEach(node => {
+          node.innerHTML = formatCurrency(amount / 100);
+        });
+
+        this.setState({ page: PAGE_PAYMENT });
+      }
     });
 
     // Toggle fund to donate to
@@ -144,10 +152,6 @@ export default class DonationFlow extends Widget {
   }
   render() {
     const { page, fund, amount, paymentMethod } = this.state;
-
-    this.sectionDonateValues.forEach(node => {
-      node.innerHTML = this.customDonationCustomInputEl.value;
-    });
 
     // Page
     this.sectionEls.forEach(el => {


### PR DESCRIPTION
As the final preview amount needed to get updated with the user selection, that update used to be made on every change of the view, instead, this code updates the HTML only when the final view is about to get rendered.

Closes #127 

# Note
The error described at #127 doesn't provide clear information of the error. In that sense, I haven't been able to reproduce it, nevertheless, the fact of not update the HTML on every render may somehow help to have a better approach and potentially avoid the error.