### PR TITLE
fix(Information): Remove deprecated method usage on _handleDeactivateDispute

### DIFF
--- a/src/javascripts/components/disputes/Information.js
+++ b/src/javascripts/components/disputes/Information.js
@@ -125,11 +125,9 @@ export default class DisputesInformation extends Widget {
       return this.deactivateDisputeForm.submit();
     }
 
-    if (confirm('Are you sure you want to delete this dispute?')) {
-      this._confirmDeactivateDispute();
+    if (!confirm('Are you sure you want to delete this dispute?')) {
+      event.preventDefault();
     }
-
-    event.preventDefault();
   }
 
   _bindMoreInfoModal() {


### PR DESCRIPTION
This code will keep the confirmation step when a dispute with information is about to get deleted,
but removing the deprecated call to the method _confirmDeactivateDispute as it does no longer exist.

Closes #111 