### PR TITLE
fix(Admin): disabling admin assignment for Disputes without a Dispute thread

### DIFF
--- a/src/javascripts/components/admin/disputes/AdminDisputesAddStatusForm.js
+++ b/src/javascripts/components/admin/disputes/AdminDisputesAddStatusForm.js
@@ -157,6 +157,12 @@ export default class AdminDisputesAddStatusForm extends Widget {
 
     this.statusesWrapper.appendChild(fragmentStatus);
 
-    this.disputeThreadLink.href = dispute.disputeThreadLink;
+    // hide button unless there's a dispute thread created
+    if (dispute.disputeThreadId) {
+      this.disputeThreadLink.href = dispute.disputeThreadLink;
+      this.disputeThreadLink.style.display = '';
+    } else {
+      this.disputeThreadLink.style.display = 'none';
+    }
   }
 }

--- a/src/javascripts/components/admin/disputes/AdminDisputesIndexController.js
+++ b/src/javascripts/components/admin/disputes/AdminDisputesIndexController.js
@@ -13,13 +13,13 @@ import ManageDisputeAdmins from './ManageDisputeAdmins.vue';
  * @param {string} disputeId The initial dispute id for which the component
  * will load assigned admins
  * @returns {ManageDisputeAdmins} the manage dispute admins instance
- * for calling setDisputeId on later whenever the edit dispute modal changes
+ * for calling setDispute on later whenever the edit dispute modal changes
  */
-const mountManageDisputeAdmins = disputeId =>
+const mountManageDisputeAdmins = () =>
   new Vue({
     el: '#manage-assigned-admin-vue',
     render() {
-      return <ManageDisputeAdmins initialDisputeId={disputeId} />;
+      return <ManageDisputeAdmins />;
     },
   }).$children[0];
 
@@ -100,6 +100,8 @@ export default class AdminDisputesIndexController extends Widget {
     this.pagination = document.querySelector('.Pagination .btn-group');
 
     this._bindEvents();
+
+    this.manageDisputeAdmins = mountManageDisputeAdmins();
   }
 
   _bindEvents() {
@@ -139,13 +141,7 @@ export default class AdminDisputesIndexController extends Widget {
 
     this.AdminDisputesIndexTable.bind('addStatus', data => {
       this.AdminDisputesAddStatusForm.updateData(data.dispute);
-
-      if (this.manageDisputeAdmins) {
-        this.manageDisputeAdmins.setDisputeId(data.dispute.id);
-      } else {
-        this.manageDisputeAdmins = mountManageDisputeAdmins(data.dispute.id);
-      }
-
+      this.manageDisputeAdmins.setDispute(data.dispute);
       this.addStatusModal.activate();
     });
 

--- a/src/javascripts/components/admin/disputes/ManageDisputeAdmins.vue
+++ b/src/javascripts/components/admin/disputes/ManageDisputeAdmins.vue
@@ -1,22 +1,22 @@
 <template>
   <div>
-    <alert :alerts="alerts" />
+    <alert :alerts="alerts"/>
     <form class="pb3" @submit="e => e.preventDefault()">
       <h3 class="pb3">Manage Admins</h3>
       <Multiselect
         v-model="assigned"
         :options="all"
         :multiple="true"
+        :disabled="!disputeThreadId"
         track-by="id"
         :custom-label="o => o.safeName"
       />
       <button
         class="-fw -k-btn btn-primary -fw-600 mt2 mb2"
         @click="save"
+        :disabled="!disputeThreadId"
         type="button"
-      >
-        Save
-      </button>
+      >Save</button>
     </form>
   </div>
 </template>
@@ -32,27 +32,29 @@ export default {
     Multiselect,
     Alert,
   },
-  props: {
-    initialDisputeId: {
-      type: String,
-      required: true,
-    },
-  },
   data() {
     return {
       assigned: [],
       originalAssigned: [],
       all: [],
-      disputeId: this.initialDisputeId,
+      dispute: {},
       alerts: [],
     };
   },
-  created() {
-    this.getAvailableAndAssignedAdmins();
+  computed: {
+    disputeThreadId: function() {
+      if (this.dispute) {
+        return this.dispute.disputeThreadId;
+      }
+    },
   },
   methods: {
     save() {
-      return updateAdmins(this.disputeId, this.assigned.map(a => a.id)).then(
+      if (!this.dispute) {
+        return;
+      }
+
+      return updateAdmins(this.dispute.id, this.assigned.map(a => a.id)).then(
         () =>
           (this.alerts = [
             {
@@ -65,13 +67,13 @@ export default {
     setAssigned(assigned) {
       this.assigned = [...assigned];
     },
-    setDisputeId(disputeId) {
-      this.disputeId = disputeId;
+    setDispute(dispute) {
+      this.dispute = dispute;
       this.alerts = [];
       this.getAvailableAndAssignedAdmins();
     },
     getAvailableAndAssignedAdmins() {
-      getAvailableAndAssignedAdmins(this.disputeId).then(({ assigned, available }) => {
+      getAvailableAndAssignedAdmins(this.dispute.id).then(({ assigned, available }) => {
         this.all = [...assigned, ...available];
         this.assigned = this.originalAssigned = [...assigned];
       });


### PR DESCRIPTION
Disabling admin assignment until the dispute changes status to prevent admin assignment going out of
sync with Discourse

fix #138

## Media
**with dispute thread id**
![image](https://user-images.githubusercontent.com/849872/52681788-be42ce00-2f02-11e9-83d2-e3df0336cc16.png)

**without dispute thread id**
![image](https://user-images.githubusercontent.com/849872/52681819-dd416000-2f02-11e9-82b3-bbd2f164f856.png)
