### PR TITLE
fix(SessionController): Handle passport.authenticate that resolves without user

### DIFF
--- a/controllers/SessionsController.js
+++ b/controllers/SessionsController.js
@@ -23,7 +23,9 @@ const SessionsController = Class('SessionsController').inherits(BaseController)(
     },
 
     callback(req, res, next) {
-      return passport.authenticate('discourse', (err, user) => {
+      return passport.authenticate('discourse', (err, user, ...rest) => {
+        const [challenge, status] = rest;
+
         if (err) {
           req.flash(
             'error',
@@ -31,6 +33,11 @@ const SessionsController = Class('SessionsController').inherits(BaseController)(
           );
 
           Sentry.captureException(err);
+          return res.redirect(config.router.helpers.root.url());
+        }
+
+        if (!user) {
+          Sentry.captureMessage('Authentication has resolved without user', { challenge, status });
           return res.redirect(config.router.helpers.root.url());
         }
 


### PR DESCRIPTION
Add extra case whenever the authentication fails without user or error **(Typically invalid signature
when trying to access to callback from SessionController)** for those cases we will send a message to sentry with extra information from executed Strategy and redirect to home avoiding the app to crash.

Closes #122 