### PR TITLE
Add improvements to error handling and avoid false bug reports

### DIFF
--- a/lib/errors/AuthenticationFailure.js
+++ b/lib/errors/AuthenticationFailure.js
@@ -1,1 +1,6 @@
-module.exports = class AuthenticationFailure extends Error {};
+module.exports = class AuthenticationFailure extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AuthenticationFailure';
+  }
+};

--- a/lib/errors/BadRequest.js
+++ b/lib/errors/BadRequest.js
@@ -1,1 +1,6 @@
-module.exports = class BadRequest extends Error {};
+module.exports = class BadRequest extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'BadRequest';
+  }
+};

--- a/lib/errors/ForbiddenError.js
+++ b/lib/errors/ForbiddenError.js
@@ -1,6 +1,6 @@
 module.exports = class ForbiddenError extends Error {
-  constructor() {
-    super();
+  constructor(message) {
+    super(message);
     this.name = 'ForbiddenError';
   }
 };

--- a/lib/passport/discourse.js
+++ b/lib/passport/discourse.js
@@ -1,6 +1,9 @@
 const PassportStrategy = require('passport-strategy');
 const sso = require('$services/sso');
 const { Sentry } = require('$lib');
+const {
+  errors: { AuthenticationFailure },
+} = require('$lib');
 
 class DiscourseStrategy extends PassportStrategy {
   constructor() {
@@ -16,8 +19,13 @@ class DiscourseStrategy extends PassportStrategy {
       try {
         user = await sso.handlePayload(payload);
       } catch (e) {
-        Sentry.captureException(e);
-        return this.fail('handlePayload error');
+        if (e instanceof AuthenticationFailure) {
+          Sentry.captureMessage(e.message);
+        } else {
+          Sentry.captureException(e);
+        }
+
+        return this.fail(e.message);
       }
 
       this.success(user);

--- a/services/sso.js
+++ b/services/sso.js
@@ -93,7 +93,7 @@ const sso = {
       return user;
     }
 
-    throw new AuthenticationFailure();
+    throw new AuthenticationFailure('Invalid sso');
   },
 };
 


### PR DESCRIPTION
Currently, sometimes after click "login" in the dispute tools app and successfully write credentials in Discourse app, the callback from SessionController gets called twice with the same SSO Value which then leads to the second call that throws AuthenticationFailure. 

While being called twice may be a bug to fix, the fact of using the same sso value and report AuthenticationFailure is not, in that sense,  this code will allow to just send a notice to the error monitor about what just happened and keep the "watch" for an exception in case something unexpected happen. 

Ultimately, this code adds some extra properties missing for custom errors to avoid empty errors from being triggered.

Closes #121 