### PR TITLE
Replace `startsWith` by `indexOf` for cross browser compatibility

### DIFF
--- a/lib/data/form-definitions/validations.js
+++ b/lib/data/form-definitions/validations.js
@@ -162,16 +162,14 @@ class Field {
   static getAttributesFromValidations(validations, attributes = {}) {
     return validations.reduce((attrs, validation) => {
       if (typeof validation !== 'string') {
-        // eslint-disable-next-line
-        console.warn('Trying to add attributes over invalid validations');
-        return attrs;
+        throw new Error('Trying to add attributes over invalid validations');
       }
 
-      if (validation.startsWith('maxLength')) {
+      if (validation.indexOf('maxLength') === 0) {
         return Object.assign({ maxlength: validation.split(':')[1] }, attrs);
       }
 
-      if (validation.startsWith('minLength')) {
+      if (validation.indexOf('minLength') === 0) {
         return Object.assign({ minlength: validation.split(':')[1] }, attrs);
       }
 

--- a/services/formValidation.js
+++ b/services/formValidation.js
@@ -137,7 +137,7 @@ const filterDependentFields = (form, config) =>
   _.reduce(
     config,
     (filtered, validations, fieldName) => {
-      const hasDependency = validations.find(e => e.startsWith('dependsOn'));
+      const hasDependency = validations.find(e => e.indexOf('dependsOn') === 0);
 
       if (!hasDependency) return { ...filtered, [fieldName]: validations };
 
@@ -147,7 +147,7 @@ const filterDependentFields = (form, config) =>
         return filtered;
       }
 
-      return { ...filtered, [fieldName]: validations.filter(e => !e.startsWith('dependsOn')) };
+      return { ...filtered, [fieldName]: validations.filter(e => !(e.indexOf('dependsOn') === 0)) };
     },
     {},
   );

--- a/tests/form-validations/Field.test.js
+++ b/tests/form-validations/Field.test.js
@@ -130,12 +130,10 @@ describe('Field', () => {
     });
 
     describe('when unexpected validations format', () => {
-      it('returns empty object', () => {
-        const spy = chai.spy.on(console, 'warn', msg => msg);
+      it('behaves as expected', () => {
         const validations = [{ rule: 'foo' }];
 
-        expect(Field.getAttributesFromValidations(validations, {})).to.deep.equal({});
-        expect(spy).to.have.been.called();
+        expect(() => Field.getAttributesFromValidations(validations, {})).to.throw();
       });
     });
   });


### PR DESCRIPTION
After realize startsWith is not supported with the same signature over IE, the idea is to change to use
indexOf instead. Check comment at https://github.com/debtcollective/dispute-tools/issues/145#issuecomment-464822580

Besides, keep in mind that the cases changed here has their tests and as will be expected they pass successfully.

Closes #145 