### PR TITLE
fix(form-element): Change computation of checked attribute to always return boolean values

### DIFF
--- a/views/mixins/dispute-tools/form-element.pug
+++ b/views/mixins/dispute-tools/form-element.pug
@@ -111,7 +111,7 @@ mixin toolsFormElementMixin(field, index)
             type="checkbox"
             name=`fieldValues[${field.name}]`
             id= field.name + field.attributes.value
-            checked= Array.isArray(_formData[field.name]) ? _formData[field.name].includes(field.attributes.value) : _formData[field.name]
+            checked= _formData[field.name].indexOf(field.attributes.value) >= 0
             value='yes'
             aria-label= field.label
             data-name=field.name


### PR DESCRIPTION
Before, the computation used to map to "_formData[field.name]" value itself whenever the value of it
weren't string which make impossible to mark unchecked inputs, instead, this code introduces a
consistent way to know if the input should be checked TRUE or FALSE.

Closes #149 

## Attachments
![http://recordit.co/mKgE20cU8i](http://recordit.co/mKgE20cU8i.gif)