### PR TITLE
Allow custom `oneOf` rule to being able to handle required fields

### DIFF
--- a/lib/data/form-definitions/credit-report-dispute.js
+++ b/lib/data/form-definitions/credit-report-dispute.js
@@ -129,7 +129,7 @@ module.exports = {
                     type: 'group',
                     name: 'agencies',
                     label: 'Agencies',
-                    validations: ['oneOf: Experian, Equifax, TransUnion :true'],
+                    validations: ['oneOf: Experian, Equifax, TransUnion :true:required'],
                     customSelector: {
                       DOM() {
                         const elements = document.querySelectorAll('[name="fieldValues[agencies]"');

--- a/services/formValidation.js
+++ b/services/formValidation.js
@@ -133,13 +133,18 @@ logger.info('Caching form validation configurations');
 
 const isNegative = answer => ['no', 'off', false, undefined].includes(answer);
 
-const filterDependentFields = (form, config) =>
-  _.reduce(
-    config,
+const filterDependentFields = (form, constraints) => {
+  const filteredFields = _.reduce(
+    constraints,
     (filtered, validations, fieldName) => {
       const hasDependency = validations.find(e => e.indexOf('dependsOn') === 0);
 
-      if (!hasDependency) return { ...filtered, [fieldName]: validations };
+      if (!hasDependency) {
+        return {
+          ...filtered,
+          [fieldName]: validations,
+        };
+      }
 
       const dependsOn = _.last(hasDependency.split(':'));
 
@@ -147,11 +152,16 @@ const filterDependentFields = (form, config) =>
         return filtered;
       }
 
-      return { ...filtered, [fieldName]: validations.filter(e => !(e.indexOf('dependsOn') === 0)) };
+      return {
+        ...filtered,
+        [fieldName]: validations.filter(e => !(e.indexOf('dependsOn') === 0)),
+      };
     },
     {},
   );
 
+  return filteredFields;
+};
 module.exports = {
   extractToolFormValidations,
   getCheckitConfig,

--- a/shared/Checkit.js
+++ b/shared/Checkit.js
@@ -3,7 +3,7 @@ const Checkit = require('checkit');
 const moment = require('moment');
 
 const getOptions = (options, caseSensitive) => {
-  if (caseSensitive !== 'false') {
+  if (caseSensitive) {
     return options.split(',').map(_.trim);
   }
 
@@ -24,9 +24,9 @@ Checkit.Validator.prototype.ssn = function ssn(val) {
   return matched !== null && matched.length === 9;
 };
 
-Checkit.Validator.prototype.oneOf = function oneOf(value, options, _caseSensitive) {
+Checkit.Validator.prototype.oneOf = function oneOf(value, options, _caseSensitive = 'false') {
   const caseSensitive = _caseSensitive !== 'false';
-  const normalizedOptions = getOptions(options);
+  const normalizedOptions = getOptions(options, caseSensitive);
 
   if (_.isEmpty(value)) {
     return true;

--- a/shared/Checkit.js
+++ b/shared/Checkit.js
@@ -24,11 +24,16 @@ Checkit.Validator.prototype.ssn = function ssn(val) {
   return matched !== null && matched.length === 9;
 };
 
-Checkit.Validator.prototype.oneOf = function oneOf(value, options, _caseSensitive = 'false') {
-  const caseSensitive = _caseSensitive !== 'false';
+Checkit.Validator.prototype.oneOf = function oneOf(value, options, ...flags) {
+  const [_caseSensitive, _required] = flags;
+  const caseSensitive = _.isEmpty(_caseSensitive) ? true : _caseSensitive === 'true';
+  const required = _.isEmpty(_required) ? false : _required === 'required';
+
   const normalizedOptions = getOptions(options, caseSensitive);
 
   if (_.isEmpty(value)) {
+    if (required) return false;
+
     return true;
   }
 

--- a/shared/Checkit.js
+++ b/shared/Checkit.js
@@ -32,9 +32,8 @@ Checkit.Validator.prototype.oneOf = function oneOf(value, options, ...flags) {
   const normalizedOptions = getOptions(options, caseSensitive);
 
   if (_.isEmpty(value)) {
-    if (required) return false;
-
-    return true;
+    // When value is empty the field will be valid only if it's not required
+    return !required;
   }
 
   if (Array.isArray(value)) {

--- a/src/javascripts/components/disputes/InformationForm.js
+++ b/src/javascripts/components/disputes/InformationForm.js
@@ -362,7 +362,8 @@ export default class DisputesInformationForm extends Widget {
     this._clearFieldErrors();
 
     const form = this._getFieldsData();
-    const [err] = new Checkit(filterDependentFields(form, this.constraints)).validateSync(form);
+    const normalizedConstrains = filterDependentFields(form, this.constraints);
+    const [err] = new Checkit(normalizedConstrains).validateSync(form);
 
     if (err) {
       ev.preventDefault();

--- a/tests/unit/shared/CheckitTests.js
+++ b/tests/unit/shared/CheckitTests.js
@@ -92,6 +92,15 @@ describe('Debt Collective Checkit extensions', () => {
       expect(err).null;
       expect(res).exist;
     });
+
+    describe('when required option added', () => {
+      it('do not pass on empty array', () => {
+        const checkit = new Checkit({ enumed: ['oneOf:Hello, world, MONSTERS:false:required'] });
+        const [err, res] = checkit.validateSync({ enumed: [] });
+        expect(err).exist;
+        expect(res).null;
+      });
+    });
   });
 
   describe('parsableDate', () => {


### PR DESCRIPTION
It is important to understand that we are using an unmaintained library to handle validations, while it is powerful there are some lack of features and documentation, with that being said, currently when a dev create a rule for a field like `["oneOf: <values>", "required"]` we face the following scenario:

- a field may be intended for an array of options, thus, select no options will result on value `[]`
- `[]` is a value which will make the "required" built-in option pass

For the above scenario, we need to explicitly say to our custom rule that: "If the field is required and the value is empty then fail". It is also imperative to understand that the expectations for the rule as it was built is to pass on empty values check https://github.com/debtcollective/dispute-tools/blob/197e4cac47399ab4165d1ee14d834f3c117ebc98/tests/unit/shared/CheckitTests.js#L90

## TL;DR
We are adding an edge case to the `oneOf` custom rule to avoid mess up other forms validations.

## Attachments
![http://recordit.co/v3D43vc7U5](http://recordit.co/v3D43vc7U5.gif)