### PR TITLE
Using lodash _.find instead of native Array.find

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,4 +25,5 @@ test:
     - yarn build
   script:
     - yarn test
+    - yarn test:form-validations
     - yarn report

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,5 +25,5 @@ test:
     - yarn build
   script:
     - yarn test
-    - yarn test:form-validations
+    - yarn test:documents
     - yarn report

--- a/services/formValidation.js
+++ b/services/formValidation.js
@@ -28,7 +28,8 @@ const flattenFieldSet = fieldSet =>
 
 const extractToolFormValidations = tool =>
   _.map(tool.options, (option, optionName) => {
-    const form = _.find(option.steps, s => s.type === 'form');
+    const steps = option.steps;
+    const form = _.find(steps, s => s.type === 'form');
 
     const { fields, nameLabels, customSelectors } = _.flattenDeep(
       form.fieldSets.map(flattenFieldSet),

--- a/services/formValidation.js
+++ b/services/formValidation.js
@@ -28,7 +28,7 @@ const flattenFieldSet = fieldSet =>
 
 const extractToolFormValidations = tool =>
   _.map(tool.options, (option, optionName) => {
-    const form = option.steps.find(s => s.type === 'form');
+    const form = _.find(option.steps, s => s.type === 'form');
 
     const { fields, nameLabels, customSelectors } = _.flattenDeep(
       form.fieldSets.map(flattenFieldSet),
@@ -137,7 +137,7 @@ const filterDependentFields = (form, constraints) => {
   const filteredFields = _.reduce(
     constraints,
     (filtered, validations, fieldName) => {
-      const hasDependency = validations.find(e => e.indexOf('dependsOn') === 0);
+      const hasDependency = _.find(validations, e => e.indexOf('dependsOn') === 0);
 
       if (!hasDependency) {
         return {

--- a/tests/documents/credit-report-dispute-letter.test.js
+++ b/tests/documents/credit-report-dispute-letter.test.js
@@ -39,5 +39,7 @@ describe('credit report dispute', () => {
     const documents = await render(dispute);
 
     console.error(documents);
+
+    return documents;
   });
 });

--- a/tests/unit/services/renderTests.js
+++ b/tests/unit/services/renderTests.js
@@ -174,8 +174,11 @@ describe('render', () => {
 
     describe('credit report dispute letter', () => {
       let docs;
+
       it('should render the pdf', async () => {
         docs = await basicRenderTest(creditReportDispute, [2])('path');
+
+        return docs;
       });
 
       it('should render all the form data into the letter', () => {
@@ -261,6 +264,8 @@ describe('render', () => {
         let docs;
         it('should render the pdf', async () => {
           docs = await basicRenderTest(taxOffsetReviews.A, [1])();
+
+          return docs;
         });
 
         it(
@@ -278,6 +283,8 @@ describe('render', () => {
         let docs;
         it('should render the pdf', async () => {
           docs = await basicRenderTest(taxOffsetReviews.B, [1])();
+
+          return docs;
         });
 
         it(
@@ -571,35 +578,39 @@ describe('render', () => {
       });
 
       it('a: should render the pdf', async () => {
-        const [[fdf]] = await basicRenderTest(wageGarnishmentDisputes.A, [1])();
+        const docs = await basicRenderTest(wageGarnishmentDisputes.A, [1])();
+        const [[fdf]] = docs;
 
         expectCorrectForm(fdf, wageGarnishmentDisputes.A);
+
+        return docs;
       });
 
       it('b: should render the pdf', async () => {
-        const [[fdf]] = await basicRenderTest(wageGarnishmentDisputes.B, [1])();
+        const docs = await basicRenderTest(wageGarnishmentDisputes.B, [1])();
+        const [[fdf]] = docs;
 
         expectCorrectForm(fdf, wageGarnishmentDisputes.B);
 
         // because dispute option is INPERSON
         expectObjectionNum(fdf, '10');
         expect(fdf.includes('X'), 'disputeProcessCity is not selected').true;
+
+        return docs;
       });
 
       it('c: should render the pdf', async () => {
-        const [[wageGarnishentFdf]] = await basicRenderTest(wageGarnishmentDisputes.CasStudent, [
-          1,
-          1,
-        ])();
+        const docs = await basicRenderTest(wageGarnishmentDisputes.CasStudent, [1, 1])();
+        const [[wageGarnishentFdf]] = docs;
 
         expectCorrectForm(wageGarnishentFdf, wageGarnishmentDisputes.CasStudent);
+
+        return docs;
       });
 
       it('d: should render the pdf', async () => {
-        const [[wageGarnishentFdf]] = await basicRenderTest(wageGarnishmentDisputes.DasStudent, [
-          1,
-          1,
-        ])();
+        const docs = await basicRenderTest(wageGarnishmentDisputes.DasStudent, [1, 1])();
+        const [[wageGarnishentFdf]] = docs;
 
         expectCorrectForm(wageGarnishentFdf, wageGarnishmentDisputes.DasStudent);
         expectContains(wageGarnishentFdf, wageGarnishmentDisputes.DasStudent, ['schoolName']);
@@ -607,13 +618,13 @@ describe('render', () => {
         // because dispute option is BYPHONE
         expectContains(wageGarnishentFdf, wageGarnishmentDisputes.DasStudent, ['phone']);
         expectObjectionNum(wageGarnishentFdf, '12');
+
+        return docs;
       });
 
       it('e: should render the pdf', async () => {
-        const [[wageGarnishentFdf]] = await basicRenderTest(wageGarnishmentDisputes.EasParent, [
-          1,
-          1,
-        ])();
+        const docs = await basicRenderTest(wageGarnishmentDisputes.EasParent, [1, 1])();
+        const [[wageGarnishentFdf]] = docs;
 
         expectCorrectForm(wageGarnishentFdf, wageGarnishmentDisputes.EasParent);
         expectContains(wageGarnishentFdf, wageGarnishmentDisputes.EasParent, ['schoolName']);
@@ -621,6 +632,8 @@ describe('render', () => {
         // because dispute option is INPERSON
         expectObjectionNum(wageGarnishentFdf, '14');
         expect(wageGarnishentFdf.includes('X'), 'disputeProcessCity is not selected').true;
+
+        return docs;
       });
     });
   });


### PR DESCRIPTION
`Array.find` is not available in old browsers, this change fixes two issues we are getting in Sentry.

Also, we are adding the documents command

Fixes #152 
Fixes #157