### PR TITLE
fix(form-element): handling undefined data case when rendering checkboxes

### DIFF
--- a/views/mixins/dispute-tools/form-element.pug
+++ b/views/mixins/dispute-tools/form-element.pug
@@ -111,7 +111,7 @@ mixin toolsFormElementMixin(field, index)
             type="checkbox"
             name=`fieldValues[${field.name}]`
             id= field.name + field.attributes.value
-            checked= _formData[field.name].indexOf(field.attributes.value) >= 0
+            checked= Array.isArray(_formData[field.name]) ? _formData[field.name].indexOf(field.attributes.value) >= 0 : !!_formData[field.name]
             value='yes'
             aria-label= field.label
             data-name=field.name


### PR DESCRIPTION
This PR handles the case when there's no checkbox data. We are assuming that every time we check this we have an Array, but this is not the case.