### PR TITLE
Add test for case when submiting form without frontend validation

### DIFF
--- a/tests/integration/controllers/DisputesControllerTest.js
+++ b/tests/integration/controllers/DisputesControllerTest.js
@@ -166,12 +166,20 @@ describe('DisputesController', () => {
         let dispute = await createDispute(owner);
         let status = _.first(dispute.statuses);
         const url = urls.Disputes.updateDisputeData.url(dispute.id);
+        const body = {
+          command: 'setForm',
+          formName: 'personal-information-form',
+          fieldValues: {
+            name: 'Orlando Del Aguila',
+          },
+          _isDirty: true,
+        };
 
         // check dispute status is new
         expect(status.status).eql('New');
 
         // make a request to update the form
-        await testPutPage(url, setFormBody, owner);
+        await testPutPage(url, body, owner);
 
         // reload dispute
         dispute = await Dispute.findById(dispute.id);
@@ -189,6 +197,24 @@ describe('DisputesController', () => {
       it('should allow setForm', () => testOk(testPutPage(url, setFormBody, owner)));
       it('should require a valid command', () =>
         testBadRequest(testPutPage(url, { command: 'bogus' }, owner)));
+
+      it('should handle invalid data correctly', async () => {
+        const dispute = await createDispute(owner);
+        const url = urls.Disputes.updateDisputeData.url(dispute.id);
+        const body = {
+          command: 'setForm',
+          formName: 'personal-information-form',
+          fieldValues: {
+            name: null,
+          },
+        };
+
+        // make a request to update the form
+        const req = await testPutPage(url, body, owner, 'text/html');
+
+        expect(req.status).eql(200);
+        expect(req.text).to.have.string('Your form has 20 invalid values');
+      });
     });
   });
 


### PR DESCRIPTION
I'm improving the messages we return when users submit a form without frontend validation. This case shouldn't happen since we require JavaScript for the application to work.

I'm adding a test case for this behavior.

![image](https://user-images.githubusercontent.com/849872/53772613-9f55ad00-3eac-11e9-9d2b-c051ea34928e.png)

Closes #151 
