### PR TITLE
fix(information-form): Remove class that inject undesire negative margin

### DIFF
--- a/views/includes/disputes/information-form.pug
+++ b/views/includes/disputes/information-form.pug
@@ -40,7 +40,7 @@ include ../../mixins/dispute-tools/form-element
           if sets.fields
             fieldset
               each row, j in sets.fields
-                .clearfix.mxn2
+                .clearfix
                   each field, k in row
                     +toolsFormElementMixin(field, i + j + k)
 


### PR DESCRIPTION
.mxn2 is a class that use CSS Variables (like many others) nevertheless, for this case, the class
styles don't load on development because the compilation of the styles seems to not recognize the
syntax or the compilation is simply different, unlike production where the class actually inject the
intended styles and make the form inputs have negative margins.

![image](https://user-images.githubusercontent.com/1425162/53789456-b0da9b80-3f24-11e9-9177-35048e8033fc.png)

Removing it from the form children should make the fix for production.

Closes #163 