### PR TITLE
fix(DisputeStatus): preserve pendingSubmission value from lastStatus in DisputeStatus.createForDispute

### DIFF
--- a/lib/data/form-definitions/credit-report-dispute.js
+++ b/lib/data/form-definitions/credit-report-dispute.js
@@ -1,5 +1,4 @@
 /* eslint max-len: 0 */
-/* eslint max-len: 0 */
 
 const { US_STATES } = require('..');
 const Field = require('./validations');

--- a/models/DisputeStatus.js
+++ b/models/DisputeStatus.js
@@ -28,7 +28,9 @@ const DisputeStatus = Class('DisputeStatus').inherits(Krypton.Model)({
   },
 
   async createForDispute(dispute, { status, note = '' }) {
-    const repeatStatus = _.get(_.head(dispute.statuses), 'status', null) === status;
+    const lastStatus = _.head(dispute.statuses);
+    const pendingSubmission = _.get(lastStatus, 'pendingSubmission', null);
+    const repeatStatus = _.get(lastStatus, 'status', null) === status;
     const hasNote = !_.isEmpty(_.trim(note));
 
     if (repeatStatus && !hasNote) {
@@ -45,6 +47,7 @@ const DisputeStatus = Class('DisputeStatus').inherits(Krypton.Model)({
       status,
       note,
       disputeId: dispute.id,
+      pendingSubmission,
     });
 
     await disputeStatus.save();

--- a/tests/unit/models/DisputeStatus.js
+++ b/tests/unit/models/DisputeStatus.js
@@ -43,6 +43,28 @@ describe('Dispute Status', () => {
       expect(newStatus.note).eq(note);
     });
 
+    it('should keep the same pendingSubmission value from last status', async () => {
+      let dispute = await createDispute(user);
+      const status = new DisputeStatus({
+        status: DisputeStatuses.completed,
+        disputeId: dispute.id,
+        pendingSubmission: true,
+      });
+
+      await status.save();
+
+      // reload dispute
+      dispute = await Dispute.findById(dispute.id);
+
+      const newStatus = await DisputeStatus.createForDispute(dispute, {
+        status: DisputeStatuses.completed,
+        note: 'test note',
+      });
+
+      expect(status.pendingSubmission).eq(true);
+      expect(newStatus.pendingSubmission).eq(status.pendingSubmission);
+    });
+
     describe('notification', () => {
       let sent;
       let safeSend;


### PR DESCRIPTION
This method is used in the admin DisputeController and is used to add admin notes to a Dispute.
Since this value can't be changed by an admin, we make sure we keep the last value provided by the
user or default to null.

Fixes #170

## Media

![gif](http://recordit.co/3xuj26jpq1.gif)