### PR TITLE
Add creditor name to Dispute thread title

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,5 +26,5 @@ test:
     - yarn install
     - yarn build
   script:
-    - yarn test:all
+    - yarn test
     - yarn report

--- a/models/Dispute.js
+++ b/models/Dispute.js
@@ -637,6 +637,47 @@ const Dispute = Class('Dispute')
 
       return this.save();
     },
+
+    /**
+     * Normalizes and returns creditor information
+     */
+    creditor() {
+      const defaultCreditor = { name: '' };
+      const {
+        data: { forms },
+      } = this;
+
+      if (!forms) {
+        return defaultCreditor;
+      }
+      const form = forms['personal-information-form'];
+      const tool = this.disputeTool;
+
+      switch (tool.slug) {
+        case 'general-debt-dispute':
+          return {
+            name: form['agency-name'],
+            address: form['agency-address'],
+            city: form['agency-city'],
+            state: form['agency-state'],
+            zip: form['agency-zip-code'],
+          };
+        case 'credit-report-dispute':
+          return {
+            name: form.currentCreditor,
+          };
+        case 'private-student-loan-dispute':
+          return {
+            name: form['firm-name'],
+            address: form['firm-address'],
+            city: form['firm-city'],
+            state: form['firm-state'],
+            zip: form['firm-zip-code'],
+          };
+        default:
+          return defaultCreditor;
+      }
+    },
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "start:prod": "yarn db:migrate && node bin/server.js",
     "start": "node bin/server.js",
     "svg": "svg-sprite -s --symbol-dest=svg --symbol-prefix=.svg- --ss=sprite.svg --si --sx --shape-id-generator=svg-%s --dest=views/includes public/svg/*.svg",
-    "test:all": "yarn test && yarn test:documents",
     "test:checkit": "yarn mocha tests/checkit/",
     "test:debug:form-validations": "node --inspect=9220 --inspect-brk tests/form-validations.js",
     "test:debug:integration": "node --inspect=9220 --inspect-brk tests/integration.js",

--- a/services/messages/DisputeThreadOriginMessage.js
+++ b/services/messages/DisputeThreadOriginMessage.js
@@ -5,12 +5,19 @@ const DiscourseMessage = require('./DiscourseMessage');
 
 class DisputeThreadOriginMessage extends DiscourseMessage {
   constructor(member, dispute, disputeTool) {
+    let subject = `${dispute.readableId} - ${member.name || member.username} - ${
+      disputeTool.readableName
+    }`;
+    const creditor = dispute.creditor();
+
+    if (creditor.name) {
+      subject = `${subject} - ${creditor.name}`;
+    }
+
     super(DisputeThreadOriginMessage.name, null, {
       to: member.username,
       from: coordinatorRole,
-      subject: `${dispute.readableId} - ${member.name || member.username} - ${
-        disputeTool.readableName
-      }`,
+      subject,
     });
 
     this.locals = { member };

--- a/tests/unit/models/Dispute.js
+++ b/tests/unit/models/Dispute.js
@@ -290,6 +290,93 @@ describe('Dispute', () => {
       });
     });
 
+    describe('creditor', () => {
+      describe('general-debt-dispute', () => {
+        it('returns creditor information available in the dispute', async () => {
+          const tool = await DisputeTool.findBySlug('general-debt-dispute');
+          const dispute = await createDispute(user, tool);
+          dispute.data = {
+            forms: {
+              'personal-information-form': {
+                'agency-name': 'Creditor name',
+                'agency-address': 'Creditor address',
+                'agency-city': 'Creditor city',
+                'agency-state': 'Creditor state',
+                'agency-zip-code': '94115',
+              },
+            },
+          };
+
+          const creditor = dispute.creditor();
+
+          expect(creditor).to.exist;
+          expect(creditor.name).to.eq('Creditor name');
+          expect(creditor.address).to.eq('Creditor address');
+          expect(creditor.city).to.eq('Creditor city');
+          expect(creditor.state).to.eq('Creditor state');
+          expect(creditor.zip).to.eq('94115');
+        });
+      });
+
+      describe('credit-report-dispute', () => {
+        it('returns creditor information available in the dispute', async () => {
+          const tool = await DisputeTool.findBySlug('credit-report-dispute');
+          const dispute = await createDispute(user, tool);
+          dispute.data = {
+            forms: {
+              'personal-information-form': {
+                currentCreditor: 'Creditor name',
+              },
+            },
+          };
+
+          const creditor = dispute.creditor();
+
+          expect(creditor).to.exist;
+          expect(creditor.name).to.eq('Creditor name');
+        });
+      });
+
+      describe('private-student-loan-dispute', () => {
+        it('returns creditor information available in the dispute', async () => {
+          const tool = await DisputeTool.findBySlug('private-student-loan-dispute');
+          const dispute = await createDispute(user, tool);
+          dispute.data = {
+            forms: {
+              'personal-information-form': {
+                'firm-name': 'Creditor name',
+                'firm-address': 'Creditor address',
+                'firm-city': 'Creditor city',
+                'firm-state': 'Creditor state',
+                'firm-zip-code': '94115',
+              },
+            },
+          };
+
+          const creditor = dispute.creditor();
+
+          expect(creditor).to.exist;
+          expect(creditor.name).to.eq('Creditor name');
+          expect(creditor.address).to.eq('Creditor address');
+          expect(creditor.city).to.eq('Creditor city');
+          expect(creditor.state).to.eq('Creditor state');
+          expect(creditor.zip).to.eq('94115');
+        });
+      });
+
+      describe('default', () => {
+        it('returns object with empty name attribute', async () => {
+          const tool = await DisputeTool.findBySlug('tax-offset-dispute');
+          const dispute = await createDispute(user, tool);
+
+          const creditor = dispute.creditor();
+
+          expect(creditor).to.exist;
+          expect(creditor.name).to.eq('');
+        });
+      });
+    });
+
     describe('search', () => {
       const containsDispute = ids => expect(ids).to.contain(dispute.id);
 


### PR DESCRIPTION
**What:** Add creditor name to Dispute thread title

**Why:** Close #176 

**How:**

- Add `dispute.creditor` method
- Use creditor name when creating the Discourse thread

## Media

![image](https://user-images.githubusercontent.com/849872/58847971-5c8da780-864a-11e9-997f-390191712f43.png)
