### PR TITLE
fix(package.json): lock svg-sprite dependency to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "style-loader": "^0.19.0",
     "stylelint": "^8.4.0",
     "stylelint-config-standard": "^18.0.0",
-    "svg-sprite": "^1.3.3",
+    "svg-sprite": "1.4.0",
     "testdouble": "^1.6.0",
     "vue-loader": "^13.5.0",
     "vue-style-loader": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12309,7 +12309,7 @@ supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
-svg-sprite@^1.3.3:
+svg-sprite@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/svg-sprite/-/svg-sprite-1.4.0.tgz#583bddc86950ca3d5d8ac249b6f1cae2c41ff557"
   integrity sha1-WDvdyGlQyj1disJJtvHK4sQf9Vc=


### PR DESCRIPTION
**What:** Locking `svg-sprite` version to 1.4.0

**Why:** We used initially the 1.3.3 version, but since the semver range was open to minor updates, the 1.5.0 version was installed and didn't work with our code.

**How:** Locking the version in package.json
