### PR TITLE
fix: prevent dispute download links to be expanded by Discourse

### DIFF
--- a/views/messages/CompletedDisputeMessage.md.js
+++ b/views/messages/CompletedDisputeMessage.md.js
@@ -7,7 +7,7 @@ module.exports = ({
   dispute,
 }) => `Thank you for disputing your debt! You can download a copy of your dispute here:
 
-${makeDisputeDownloadUrl(dispute)}
+> ${makeDisputeDownloadUrl(dispute)}
 
 If you opted to mail the dispute yourself, it is a good idea to send it certified mail so you can be sure it was received. If you need help mailing it, we will send you the tracking info once it is sent.
 


### PR DESCRIPTION
**What:** Escape links from Onebox

**Why:** Onebox is what Discourse uses to expand links they issue we are having is that it tries to expand our Dispute download link and fails because requires a valid session, and uses the SSO link instead. Closes #184 

**How:** By wrapping the link in a blockquote we prevent Onebox from expanding the link.