### PR TITLE
dev: log using logger instead of console log. report errors to sentry

### DIFF
--- a/controllers/Admin/DisputesController.js
+++ b/controllers/Admin/DisputesController.js
@@ -8,6 +8,7 @@ const DisputeAttachment = require('$models/DisputeAttachment');
 const config = require('$config/config');
 const RestfulController = require('$lib/core/controllers/RestfulController');
 const _ = require('lodash');
+const { Sentry, logger } = require('$lib');
 
 const {
   authenticate,
@@ -139,7 +140,8 @@ Admin.DisputesController = Class(Admin, 'DisputesController').inherits(RestfulCo
         .getAssignedAndAvailableAdmins()
         .then(r => res.status(200).send(r))
         .catch(e => {
-          console.log('error: ', e);
+          Sentry.captureException(e);
+          logger.error(e.message);
           next(e);
         });
     },
@@ -152,7 +154,8 @@ Admin.DisputesController = Class(Admin, 'DisputesController').inherits(RestfulCo
           res.status(200).send({});
         })
         .catch(e => {
-          console.log('error: ', e);
+          Sentry.captureException(e);
+          logger.error(e.message);
           next(e);
         });
     },

--- a/controllers/DisputesController.js
+++ b/controllers/DisputesController.js
@@ -125,7 +125,7 @@ const DisputesController = Class('DisputesController').inherits(RestfulControlle
         await new CompletedDisputeMessage(dispute).send();
       } catch (e) {
         Sentry.captureException(e);
-        logger.error(e);
+        logger.error(e.message);
       }
 
       return redirect();
@@ -225,6 +225,7 @@ const DisputesController = Class('DisputesController').inherits(RestfulControlle
           'A problem occurred while attempting to upload your attachments. Please try again or contact us if the problem persists.',
         );
         logger.error('Unable to upload attachment', e.message);
+        Sentry.captureException(e);
         caught = e;
       }
 


### PR DESCRIPTION
**What:** log using logger instead of console log. report errors to sentry 

**Why:** right now when we log the whole error, it outputs something that is hard to read in the logs. Since we are sending the error to Sentry and have all the error information there, by just having the message in the logs should be enough

**How:**

- Import `logger` and replace `console.error` for `logger.error`
- Add Sentry notification to caught errors
