### PR TITLE
fix(dtr): fix doe link

### DIFF
--- a/views/dispute-tools/index.pug
+++ b/views/dispute-tools/index.pug
@@ -40,7 +40,7 @@ block content
             hr.mb2
             a.-k-btn.btn-primary.-fw.-fw-600(
               id='defense-to-repayment-link'
-              href='https://borrowerdischarge.ed.gov/FormWizard/BDU/BDULanding.aspx' rel='noopener noreferrer'
+              href='https://studentaid.gov/borrower-defense/' rel='noopener noreferrer'
               target='_blank'
               class= !user && 'js-login-link'
             ) More information
@@ -121,7 +121,7 @@ block append body
               id='stay-button'
             ) Stay
             a.-k-btn.btn-primary.-fw.-fw-600.ml2(
-              href='https://borrowerdischarge.ed.gov/FormWizard/BDU/BDULanding.aspx' rel='noopener noreferrer'
+              href='https://studentaid.gov/borrower-defense/' rel='noopener noreferrer'
               target='_blank'
               id='continue-button'
             ) Continue

--- a/views/home/dtr.pug
+++ b/views/home/dtr.pug
@@ -17,7 +17,7 @@ block content
         p.mb3.
           Defense to Repayment (DTR) is a federal law that says people defrauded by their school have a right to the cancellation of their federal loans.
         p.mb3.
-          You can file a DTR on the #[a(href='https://borrowerdischarge.ed.gov/FormWizard/BDU/BDULanding.aspx' target='_blank' rel='noopener noreferrer') Department of Education's website].
+          You can file a DTR on the #[a(href='https://studentaid.gov/borrower-defense/' target='_blank' rel='noopener noreferrer') Department of Education's website].
 
         p.mb3.
           You should file this dispute if you believe your school lied to you about costs or job placement rates,
@@ -64,4 +64,4 @@ block content
           more, or if you have questions about DTR.
 
         p.mb3.
-          #[a.-k-btn.btn-primary.-fw.-fw-600(href='https://borrowerdischarge.ed.gov/FormWizard/BDU/BDULanding.aspx' rel='noopener noreferrer' target='_blank') Start Defense to Repayment]
+          #[a.-k-btn.btn-primary.-fw.-fw-600(href='https://studentaid.gov/borrower-defense/' rel='noopener noreferrer' target='_blank') Start Defense to Repayment]


### PR DESCRIPTION
**What:** fix DOE link to borrower defense to repayment tool

**Why:** This broken link was reported by the dispute tools team

**How:**

- change URL for the right one
