### PR TITLE
Use correct link for join the union header item

### DIFF
--- a/views/includes/header.pug
+++ b/views/includes/header.pug
@@ -13,7 +13,7 @@
         text: 'My Disputes'
       },
       {
-        href: '/debt-union',
+        href: 'https://debtcollective.org/debt-union',
         text: 'Join the Union'
       },
       {


### PR DESCRIPTION
**What:**
Use the correct link for the join the union header item

**Why:**
Closes: https://app.asana.com/0/1159164196409156/1199606858026341/f

**How:**
Replace the link for the `Join the union` item to redirect to the home page
