### PR TITLE
feat(contact-us): include a subject dropdown

### DIFF
--- a/HOW_TO.md
+++ b/HOW_TO.md
@@ -28,13 +28,13 @@ The doc-comments on the `Email` and `DiscourseMessage` classes are essential rea
 
 # Emails in Development
 
-We are using [mailcatcher](https://mailcatcher.me/) to visualize emails
+We are using [MailHog](https://github.com/mailhog/MailHog) to visualize emails
 in development, to install:
 
--   `gem install mailcatcher`
--   Run `mailcatcher`
+-   `brew update && brew install mailhog`
+-   Run `mailhog`
 -   Send mail through `smtp://localhost:1025` (If you copied `config.sample.js` this is already configured for you)
--   Go to `http://localhost:1080/` to see emails
+-   Go to `http://localhost:8025/` to see emails
 
 # S3 in Development
 

--- a/controllers/HomeController.js
+++ b/controllers/HomeController.js
@@ -46,10 +46,10 @@ const HomeController = Class('HomeController').inherits(BaseController)({
     },
 
     sendContact(req, res, next) {
-      const { name, email, message, 'g-recaptcha-response': recaptchaResponse } = req.body;
+      const { name, email, message, subject, 'g-recaptcha-response': recaptchaResponse } = req.body;
       const recaptcha = config.recaptcha;
 
-      const contactUsEmail = new ContactUsEmail(message, email, name);
+      const contactUsEmail = new ContactUsEmail(message, email, name, subject);
 
       request.post(
         {

--- a/services/messages/ContactUsEmail.js
+++ b/services/messages/ContactUsEmail.js
@@ -11,17 +11,19 @@ class ForAdmin extends DebtCollectiveMessage {
    * @param {string} message Message for the Debt Collective organizers
    * @param {string} email The email address of the visitor contacting the Debt Collective
    * @param {string} name The name of the visitor contact the Debt Collective
+   * @param {string} subject The subject of the visitor contacting the Debt Collective
    */
-  constructor(message, email, name) {
+  constructor(message, email, name, subject) {
     super('ContactUsEmail.ForAdmin', {
       to: ForAdmin.to,
       from: `${name} <${email}>`,
-      subject: `${name} has sent a message using the Contact Us form`,
+      subject: `${subject} | ${name} has sent a message using the Contact Us form`,
     });
 
     this.locals = {
       message,
       name,
+      subject,
     };
   }
 }
@@ -36,9 +38,10 @@ class ContactUsEmail {
    * @param {string} message Message for the Debt Collective organizers
    * @param {string} email The email address of the visitor contacting the Debt Collective
    * @param {string} name The name of the visitor contact the Debt Collective
+   * @param {string} subject The subject of the visitor contacting the Debt Collective
    */
-  constructor(message, email, name) {
-    this.forAdmin = new ForAdmin(message, email, name);
+  constructor(message, email, name, subject) {
+    this.forAdmin = new ForAdmin(message, email, name, subject);
   }
 
   send() {

--- a/views/home/contact.pug
+++ b/views/home/contact.pug
@@ -12,19 +12,28 @@ block content
         .col.sm-col-3.col-12.p1.right-align.xs-left-align.-fw-500
           b Your name
         .col.sm-col-9.col-12.px1
-          input.form-control.-fw(type="text" name="name" maxLength="200" value=name)
+          input.form-control.-fw(type="text" name="name" maxLength="200" value=name required)
           p.-on-error.-danger.-caption.-fw-500.mt1 ▲ Invalid Name
       .clearfix.mb3
         .col.sm-col-3.col-12.p1.right-align.xs-left-align.-fw-500
           b Your email
         .col.sm-col-9.col-12.px1
-          input.form-control.-fw(type="email" name="email", value=email)
+          input.form-control.-fw(type="email" name="email", value=email required)
           p.-on-error.-danger.-caption.-fw-500.mt1 ▲ Invalid email
+      .clearfix.mb3
+        .col.sm-col-3.col-12.p1.right-align.xs-left-align.-fw-500
+          b Subject
+        .col.sm-col-9.col-12.px1
+          select.select.form-control.input-lg(name='subject' required)
+            - var _subjects = ['Login issues', 'Technical Support', 'Debt Questions', 'Press', 'Others'];
+            option(value='') -- Select a subject --
+            each subject in _subjects
+              option(value=subject)= subject
       .clearfix.mb2
         .col.sm-col-3.col-12.p1.right-align.xs-left-align.-fw-500
           b Your message
         .col.sm-col-9.col-12.px1
-          textarea.form-control.-fw(type="text" name="message" maxLength="32768")
+          textarea.form-control.-fw(type="text" name="message" maxLength="32768" required)
             = message
           p.-on-error.-danger.-caption.-fw-500.mt1 ▲ Invalid message
       .clearfix.mb2

--- a/views/messages/ContactUsEmail.ForAdmin.pug
+++ b/views/messages/ContactUsEmail.ForAdmin.pug
@@ -6,4 +6,6 @@ block title
 block content
   div(style="font-size: 16px; line-height: 142%;")
     div(style="font-family: sans-serif; color: #000000;")
+      p
+        strong Subject: #{subject}
       div #{message}


### PR DESCRIPTION
**What:**
Add subject dropdown to the contact us form

**Why:**
Closes: https://app.asana.com/0/1159164196409129/1200001829300735/f

**How:**
- Add the dropdown in the pug template for the contact us page
- Catch the subject in the contact us request and include it in the email subject

#### Media
https://www.loom.com/share/07e6107ddf0b45eca09f35df6c017d59
